### PR TITLE
Allow quoting of first idea post

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -87,6 +87,7 @@ class listener implements EventSubscriberInterface
 			'core.viewtopic_add_quickmod_option_before'	=> 'adjust_quickmod_tools',
 			'core.viewonline_overwrite_location'		=> 'viewonline_ideas',
 			'core.posting_modify_submit_post_after'		=> 'edit_idea_title',
+			'core.posting_modify_post_data'				=> 'update_quote_username',
 		);
 	}
 
@@ -154,7 +155,6 @@ class listener implements EventSubscriberInterface
 			$post_row = $event['post_row'];
 
 			$post_row['U_DELETE'] = false;
-			$post_row['U_QUOTE']  = false;
 			$post_row['U_WARN']   = false;
 
 			$event['post_row'] = $post_row;
@@ -345,6 +345,26 @@ class listener implements EventSubscriberInterface
 
 		$idea = $this->ideas->get_idea_by_topic_id($event['topic_id']);
 		$this->ideas->set_title($idea['idea_id'], $event['post_data']['post_subject']);
+	}
+
+	/**
+	 * When quoting the first idea post, replace the idea author username
+	 * which is normally the Ideas Bot, to the actual author's name
+	 *
+	 * @param \phpbb\event\data $event The event object
+	 * @return void
+	 * @access public
+	 */
+	public function update_quote_username($event)
+	{
+		if ($event['mode'] === 'quote' &&
+			$event['post_data']['topic_first_post_id'] == $event['post_id'] &&
+			$this->is_ideas_forum($event['forum_id']))
+		{
+			$idea = $this->ideas->get_idea_by_topic_id($event['topic_id']);
+			$username = $this->link_helper->get_user_link($idea['idea_author'], 'username');
+			$event->update_subarray('post_data', 'quote_username', $username);
+		}
 	}
 
 	/**

--- a/factory/linkhelper.php
+++ b/factory/linkhelper.php
@@ -67,12 +67,13 @@ class linkhelper
 	 *
 	 * Is there a function that already does this? This seems fairly database heavy.
 	 *
-	 * @param int $id The ID of the user
+	 * @param int    $id   The ID of the user
+	 * @param string $mode The mode, profile|username|colour|full|no_profile
 	 * @return string An HTML link to the users profile
 	 */
-	public function get_user_link($id)
+	public function get_user_link($id, $mode = 'full')
 	{
 		$this->user_loader->load_users(array($id));
-		return $this->user_loader->get_username($id, 'full');
+		return $this->user_loader->get_username($id, $mode);
 	}
 }

--- a/tests/factory/linkhelper_test.php
+++ b/tests/factory/linkhelper_test.php
@@ -104,19 +104,22 @@ class linkhelper_test extends \phpbb_database_test_case
 	public function get_user_link_test_data()
 	{
 		return array(
-			array(2, '<a href="phpBB/memberlist.php?mode=viewprofile&amp;u=2" class="username">ideabot</a>'),
-			array(3, '<a href="phpBB/memberlist.php?mode=viewprofile&amp;u=3" class="username">admin</a>'),
-			array(4, '<a href="phpBB/memberlist.php?mode=viewprofile&amp;u=4" class="username">poster</a>'),
+			array(2, 'full', '<a href="phpBB/memberlist.php?mode=viewprofile&amp;u=2" class="username">ideabot</a>'),
+			array(3, 'full', '<a href="phpBB/memberlist.php?mode=viewprofile&amp;u=3" class="username">admin</a>'),
+			array(4, 'full', '<a href="phpBB/memberlist.php?mode=viewprofile&amp;u=4" class="username">poster</a>'),
+			array(2, 'username', 'ideabot'),
+			array(3, 'username', 'admin'),
+			array(4, 'username', 'poster'),
 		);
 	}
 
 	/**
 	 * @dataProvider get_user_link_test_data
 	 */
-	public function test_get_user_link($user, $expected)
+	public function test_get_user_link($user, $mode, $expected)
 	{
 		$linkhelper = $this->get_linkhelper();
 
-		$this->assertEquals($expected, $linkhelper->get_user_link($user));
+		$this->assertEquals($expected, $linkhelper->get_user_link($user, $mode));
 	}
 }


### PR DESCRIPTION
@CHItA I think said you can't quote the first post in an idea. I guess this was intentional as the first post is made by an Ideas Bot (though I have no idea why that is the case).

Anyway this PR will allow quoting of the first idea post, but adds a bit of overhead (about 5 additional SQL queries) due to all the work needed to find the original post author's username within the posting.php codebase.

So I'm not sure this is worth having.