### PR TITLE
Correctly handle moved ideas and idea counting

### DIFF
--- a/factory/ideas.php
+++ b/factory/ideas.php
@@ -148,11 +148,19 @@ class ideas
 			$where .= ' AND i.idea_votes_up > i.idea_votes_down';
 		}
 
+		// Only get approved topics
+		$where .= ' AND t.topic_visibility = ' . ITEM_APPROVED;
+
+		// Only get ideas that are actually in the ideas forum (not ones that have been moved)
+		$where .= ' AND t.forum_id = ' . (int) $this->config['ideas_forum_id'];
+
 		// Count the total number of ideas for pagination
 		if ($number >= $this->config['posts_per_page'])
 		{
 			$sql = 'SELECT COUNT(i.idea_id) as num_ideas
-				FROM ' . $this->table_ideas . " i
+				FROM ' . $this->table_ideas . ' i
+       			INNER JOIN ' . $this->table_topics . " t 
+       				ON i.topic_id = t.topic_id
 				WHERE $where";
 			$result = $this->db->sql_query($sql);
 			$num_ideas = (int) $this->db->sql_fetchfield('num_ideas');
@@ -161,9 +169,6 @@ class ideas
 			// Set the total number of ideas for pagination
 			$this->idea_count = $num_ideas;
 		}
-
-		// Only get approved topics
-		$where .= ' AND t.topic_visibility = ' . ITEM_APPROVED;
 
 		if ($sortby !== 'TOP' && $sortby !== 'ALL')
 		{
@@ -710,7 +715,8 @@ class ideas
 		// Find any orphans
 		$sql = 'SELECT idea_id FROM ' . $this->table_ideas . '
  			WHERE topic_id NOT IN (SELECT t.topic_id 
- 			FROM ' . $this->table_topics . ' t)';
+ 			FROM ' . $this->table_topics . ' t
+ 				WHERE t.forum_id = ' . (int) $this->config['ideas_forum_id'] . ')';
 		$result = $this->db->sql_query($sql);
 		$rows = $this->db->sql_fetchrowset($result);
 		$this->db->sql_freeresult($result);

--- a/tests/fixtures/ideas.xml
+++ b/tests/fixtures/ideas.xml
@@ -97,6 +97,20 @@
 			<value></value>
 			<value></value>
 		</row>
+		<row>
+			<value>7</value>
+			<value>2</value>
+			<value>Orphaned Idea #7 New with no votes</value>
+			<value>1439999994</value>
+			<value>1</value>
+			<value>1</value>
+			<value>1</value>
+			<value>7</value>
+			<value>0</value>
+			<value>0</value>
+			<value></value>
+			<value></value>
+		</row>
 	</table>
 	<table name="phpbb_ideas_votes">
 		<column>idea_id</column>
@@ -195,30 +209,42 @@
 		<column>topic_id</column>
 		<column>topic_title</column>
 		<column>topic_visibility</column>
+		<column>forum_id</column>
 		<row>
 			<value>1</value>
 			<value>Foo Idea #1 New with 3 up votes</value>
 			<value>1</value>
+			<value>2</value>
 		</row>
 		<row>
 			<value>2</value>
 			<value>Bar Idea #2 New with 1 down vote</value>
 			<value>1</value>
+			<value>2</value>
 		</row>
 		<row>
 			<value>3</value>
 			<value>Foo Idea #3 In Progress with 1 up and 1 down vote</value>
 			<value>1</value>
+			<value>2</value>
 		</row>
 		<row>
 			<value>4</value>
 			<value>Bar Idea #4 Implemented with 0 votes</value>
 			<value>1</value>
+			<value>2</value>
 		</row>
 		<row>
 			<value>5</value>
 			<value>Unapproved Idea #5 New with 0 votes</value>
 			<value>0</value>
+			<value>2</value>
+		</row>
+		<row>
+			<value>6</value>
+			<value>Orphaned Idea #6 New with 2 votes</value>
+			<value>1</value>
+			<value>3</value>
 		</row>
 	</table>
 </dataset>


### PR DESCRIPTION
Fixes #91 

Should handle moved topics now, by ignoring ideas that belong to topics that are not in the designated ideas forum. This also means they are considered orphans, so they will also be pruned from the ideas tables too.