### PR TITLE
Try to improve old-message clean up

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -121,14 +121,14 @@ class listener implements EventSubscriberInterface
 			return;
 		}
 
-		if ($event['topic_data']['topic_first_post_id'] == $event['row']['post_id'])
+		if ($event['topic_data']['topic_first_post_id'] == $event['row']['post_id'] && $event['topic_data']['topic_time'] < strtotime('September 1, 2017'))
 		{
 			$post_row = $event['post_row'];
 			$message = $post_row['MESSAGE'];
 
 			// This freakish looking regex pattern should
 			// remove the old ideas link-backs from the message.
-			$message = preg_replace('/(<br[^>]*>\\n?)\\1-{10}\\1\\1.*/s', '', $message);
+			$message = preg_replace('/(<br[^>]*>\\n?)\\1-{10}\\1\\1.*]/s', '', $message);
 
 			$post_row['MESSAGE'] = $message;
 			$event['post_row'] = $post_row;


### PR DESCRIPTION
Broken BBCodes leave rogue closing HTML tags at the very end of the post which will get removed when we need to erase all the other old legacy junk left at the end of the post from the old Ideas. So this attempts to avoid removing any trailing tags resulting from broken bbcodes and also limits this clean up to posts made before this extension was installed.