### PR TITLE
Add post preview capability

### DIFF
--- a/controller/post_controller.php
+++ b/controller/post_controller.php
@@ -45,11 +45,10 @@ class post_controller extends base
 			include $this->root_path . 'includes/functions_display.' . $this->php_ext;
 		}
 
-		$mode = $this->request->variable('mode', '');
 		$title = $this->request->variable('title', '', true);
 		$message = $this->request->variable('message', '', true);
 
-		if ($mode === 'submit')
+		if ($this->request->is_set_post('post'))
 		{
 			$submit = $this->ideas->submit($title, $message, $this->user->data['user_id']);
 
@@ -71,6 +70,17 @@ class post_controller extends base
 			}
 		}
 
+		if ($this->request->is_set_post('preview'))
+		{
+			$preview_message = $this->ideas->preview($message);
+
+			$this->template->assign_vars(array(
+				'S_DISPLAY_PREVIEW'	=> !empty($preview_message),
+				'PREVIEW_SUBJECT'	=> $title,
+				'PREVIEW_MESSAGE'	=> $preview_message,
+			));
+		}
+
 		display_custom_bbcodes();
 		generate_smilies('inline', 0);
 
@@ -83,8 +93,9 @@ class post_controller extends base
 
 		$this->template->assign_vars(array(
 			'TITLE'				=> $title,
+			'MESSAGE'			=> $message,
 
-			'S_POST_ACTION'		=> $this->helper->route('phpbb_ideas_post_controller', array('mode' => 'submit')),
+			'S_POST_ACTION'		=> $this->helper->route('phpbb_ideas_post_controller'),
 			'S_BBCODE_ALLOWED'	=> $bbcode_status,
 			'S_SMILIES_ALLOWED'	=> $smilies_status,
 			'S_LINKS_ALLOWED'	=> $url_status,

--- a/factory/ideas.php
+++ b/factory/ideas.php
@@ -671,6 +671,19 @@ class ideas
 	}
 
 	/**
+	 * Preview a new idea.
+	 *
+	 * @param string $message The description of the idea.
+	 * @return string The idea parsed for display in preview.
+	 */
+	public function preview($message)
+	{
+		$uid = $bitfield = $flags = '';
+		generate_text_for_storage($message, $uid, $bitfield, $flags, true, true, true);
+		return generate_text_for_display($message, $uid, $bitfield, $flags);
+	}
+
+	/**
 	 * Deletes an idea and the topic to go with it.
 	 *
 	 * @param int $id       The ID of the idea to be deleted.

--- a/styles/prosilver/template/idea_new.html
+++ b/styles/prosilver/template/idea_new.html
@@ -61,6 +61,7 @@
 		<fieldset class="submit-buttons">
 			{{ S_HIDDEN_FIELDS }}
 			<input type="submit" accesskey="s" tabindex="6" name="post" value="{{ lang('SUBMIT') }}" class="button1 default-submit-action" />
+			<input type="submit" name="preview" value="{{ lang('PREVIEW') }}" class="button2" />
 		</fieldset>
 	</div>
 </div>

--- a/tests/controller/post_controller_test.php
+++ b/tests/controller/post_controller_test.php
@@ -95,11 +95,11 @@ class post_controller_test extends controller_base
 	}
 
 	/**
-	 * Test data for the test_submit_success test
+	 * Test data for the test_post_success test
 	 *
 	 * @return array Array of test data
 	 */
-	public function submit_success_data()
+	public function post_success_data()
 	{
 		return array(
 			array(true),
@@ -108,27 +108,27 @@ class post_controller_test extends controller_base
 	}
 
 	/**
-	 * Test submit
+	 * Test post
 	 *
-	 * @dataProvider submit_success_data
+	 * @dataProvider post_success_data
 	 */
-	public function test_submit_success($is_newly_registered_user)
+	public function test_post_success($is_newly_registered_user)
 	{
 		/** @var \phpbb\ideas\controller\post_controller $controller */
 		$controller = $this->get_controller('post_controller');
 		$this->assertInstanceOf('phpbb\ideas\controller\post_controller', $controller);
 
-		$this->controller_helper->expects($this->any())
+		$this->controller_helper->expects($this->once())
 			->method('route')
 			->will($this->returnValue('phpbb_ideas_idea_controller'));
 
-		$this->request->expects($this->any())
-			->method('variable')
+		$this->request->expects($this->once())
+			->method('is_set_post')
 			->will($this->returnValueMap(array(
-				array('mode', '', false, \phpbb\request\request_interface::REQUEST, 'submit'),
+				array('post', true),
 			)));
 
-		$this->auth->expects($this->any())
+		$this->auth->expects($this->once())
 			->method('acl_get')
 			->with('f_noapprove', $this->config['ideas_forum_id'])
 			->will($this->returnValue(!$is_newly_registered_user));
@@ -139,12 +139,53 @@ class post_controller_test extends controller_base
 		}
 
 		// ideas->submit() will return an idea id on successful submit
-		$this->ideas->expects($this->any())
+		$this->ideas->expects($this->once())
 			->method('submit')
 			->will($this->returnValue(1));
 
 		$response = $controller->post();
 		$this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
+	}
+
+	/**
+	 * Test preview
+	 */
+	public function test_preview()
+	{
+		/** @var \phpbb\ideas\controller\post_controller $controller */
+		$controller = $this->get_controller('post_controller');
+		$this->assertInstanceOf('phpbb\ideas\controller\post_controller', $controller);
+
+		$this->request->expects($this->any())
+			->method('is_set_post')
+			->will($this->returnValueMap(array(
+				array('post', false),
+				array('preview', true),
+			)));
+
+		$this->request->expects($this->atLeastOnce())
+			->method('variable')
+			->will($this->returnValueMap(array(
+				array('title', '', true, \phpbb\request\request_interface::REQUEST, 'test title'),
+				array('message', '', true, \phpbb\request\request_interface::REQUEST, 'test message'),
+			)));
+
+		$this->ideas->expects($this->never())
+			->method('submit');
+
+		$this->ideas->expects($this->once())
+			->method('preview')
+			->willReturn('test message');
+
+		$this->template->expects($this->at(0))
+			->method('assign_vars')
+			->with(array(
+				'S_DISPLAY_PREVIEW' => true,
+				'PREVIEW_SUBJECT'   => 'test title',
+				'PREVIEW_MESSAGE'   => 'test message'
+			));
+
+		$controller->post();
 	}
 
 	/**
@@ -156,16 +197,22 @@ class post_controller_test extends controller_base
 		$controller = $this->get_controller('post_controller');
 		$this->assertInstanceOf('phpbb\ideas\controller\post_controller', $controller);
 
-		$this->request->expects($this->any())
+		$this->request->expects($this->atLeastOnce())
+			->method('is_set_post')
+			->will($this->returnValueMap(array(
+				array('post', true),
+				array('preview', false),
+			)));
+
+		$this->request->expects($this->atLeastOnce())
 			->method('variable')
 			->will($this->returnValueMap(array(
-				array('mode', '', false, \phpbb\request\request_interface::REQUEST, 'submit'),
 				array('title', '', true, \phpbb\request\request_interface::REQUEST, 'test title'),
 				array('message', '', true, \phpbb\request\request_interface::REQUEST, 'test message'),
 			)));
 
 		// ideas->submit() will return an array of error messages on submit error
-		$this->ideas->expects($this->any())
+		$this->ideas->expects($this->once())
 			->method('submit')
 			->will($this->returnValue(array('error1', 'error2')));
 

--- a/tests/ideas/preview_idea_test.php
+++ b/tests/ideas/preview_idea_test.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ *
+ * Ideas extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\ideas\factory;
+
+class preview_idea_test extends \phpbb\ideas\tests\ideas\ideas_base
+{
+	public function setUp()
+	{
+		parent::setUp();
+
+		global $phpbb_container;
+
+		// This is needed to set up the s9e text formatter services
+		// This can lead to a test failure if PCRE is old.
+		$this->get_test_case_helpers()->set_s9e_services($phpbb_container);
+	}
+
+	/**
+	 * Test preview() data
+	 *
+	 * @return array
+	 */
+	public function preview_test_data()
+	{
+		return array(
+			array('New idea 1 posted by the test framework.'),
+			array('New idea 2 [u]posted[/u] by the test [b]framework[/b].'),
+		);
+	}
+
+	/**
+	 * Test preview()
+	 *
+	 * @dataProvider preview_test_data
+	 */
+	public function test_preview($message)
+	{
+		// Get the ideas object
+		$ideas = $this->get_ideas_object();
+
+		// store the message in a temp variable, since it will forever altered
+		$test_message = $message;
+
+		// Prepare the test message for storage
+		$uid = $bitfield = $flags = '';
+		generate_text_for_storage($test_message, $uid, $bitfield, $flags, true, true, true);
+
+		// Prepare the test message for display
+		$expected = generate_text_for_display($test_message, $uid, $bitfield, $flags);
+
+		// Actually run the original test message through preview method
+		$preview = $ideas->preview($message);
+
+		// Assert preview message was parsed and rendered as expected
+		$this->assertEquals($expected, $preview);
+	}
+}


### PR DESCRIPTION
Closes #88 

Adding Preview to post editor is a good thing. Not gonna even attempt drafts though, since the Ideas Post handler is totally its own thing separate from phpBB, so it'd just be a whole mess to even try saving drafts I think, after spending some time here with Ideas' post controller.