### PR TITLE
Improved duplicate linking

### DIFF
--- a/config/routing.yml
+++ b/config/routing.yml
@@ -17,3 +17,7 @@ phpbb_ideas_list_controller:
 phpbb_ideas_post_controller:
     path: /ideas/post
     defaults: { _controller: phpbb.ideas.post_controller:post }
+
+phpbb_ideas_livesearch_controller:
+    path: /ideas/livesearch/title
+    defaults: { _controller: phpbb.ideas.livesearch_controller:title_search }

--- a/config/services.yml
+++ b/config/services.yml
@@ -62,6 +62,10 @@ services:
         class: phpbb\ideas\controller\idea_controller
         parent: phpbb.ideas.controller.base
 
+    phpbb.ideas.livesearch_controller:
+        class: phpbb\ideas\controller\livesearch_controller
+        parent: phpbb.ideas.controller.base
+
     phpbb.ideas.ideas:
         class: phpbb\ideas\factory\ideas
         arguments:

--- a/controller/livesearch_controller.php
+++ b/controller/livesearch_controller.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ *
+ * Ideas extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\ideas\controller;
+
+/**
+ * Ideas live search controller
+ */
+class livesearch_controller extends base
+{
+	public function title_search()
+	{
+		$title_chars = $this->request->variable('duplicateeditinput', '', true);
+
+		$matches = $this->ideas->ideas_title_livesearch($title_chars, 10);
+
+		$json_response = new \phpbb\json_response();
+		$json_response->send(array(
+			'keyword' => $title_chars,
+			'results' => $matches,
+		));
+	}
+}

--- a/controller/livesearch_controller.php
+++ b/controller/livesearch_controller.php
@@ -22,9 +22,9 @@ class livesearch_controller extends base
 		$matches = $this->ideas->ideas_title_livesearch($title_chars, 10);
 
 		$json_response = new \phpbb\json_response();
-		$json_response->send(array(
+		$json_response->send([
 			'keyword' => $title_chars,
 			'results' => $matches,
-		));
+		]);
 	}
 }

--- a/event/listener.php
+++ b/event/listener.php
@@ -230,7 +230,7 @@ class listener implements EventSubscriberInterface
 			'IDEA_STATUS_NAME'	=> $this->ideas->get_status_from_id($idea['idea_status']),
 			'IDEA_STATUS_LINK'	=> $this->helper->route('phpbb_ideas_list_controller', array('status' => $idea['idea_status'])),
 
-			'IDEA_DUPLICATE'	=> $idea['duplicate_id'],
+			'IDEA_DUPLICATE'	=> $idea['duplicate_id'] ? $this->ideas->get_title($idea['duplicate_id']) : '',
 			'IDEA_RFC'			=> $idea['rfc_link'],
 			'IDEA_TICKET'		=> $idea['ticket_id'],
 			'IDEA_IMPLEMENTED'	=> $idea['implemented_version'],

--- a/event/listener.php
+++ b/event/listener.php
@@ -253,6 +253,7 @@ class listener implements EventSubscriberInterface
 			'U_EDIT_TICKET'		=> $this->link_helper->get_idea_link($idea['idea_id'], 'ticket', true),
 			'U_REMOVE_VOTE'		=> $this->link_helper->get_idea_link($idea['idea_id'], 'removevote', true),
 			'U_IDEA_VOTE'		=> $this->link_helper->get_idea_link($idea['idea_id'], 'vote', true),
+			'U_TITLE_LIVESEARCH'=> $this->helper->route('phpbb_ideas_livesearch_controller'),
 		));
 
 		// Use Ideas breadcrumbs

--- a/factory/ideas.php
+++ b/factory/ideas.php
@@ -285,7 +285,7 @@ class ideas
 				'idea_id'     => $row['idea_id'],
 				'result'      => $row['idea_id'],
 				'clean_title' => $row['idea_title'],
-				'display'     => "<span>{$row['idea_title']}</span>",
+				'display'     => "<span>{$row['idea_title']}</span>", // spans are expected in phpBB's live search JS
 			];
 		}
 		$this->db->sql_freeresult($result);

--- a/factory/ideas.php
+++ b/factory/ideas.php
@@ -445,6 +445,25 @@ class ideas
 	}
 
 	/**
+	 * Get the title of an idea.
+	 *
+	 * @param int $id ID of an idea
+	 *
+	 * @return string The idea's title
+	 */
+	public function get_title($id)
+	{
+		$sql = 'SELECT idea_title
+			FROM ' . $this->table_ideas . '
+			WHERE idea_id = ' . (int) $id;
+		$result = $this->db->sql_query_limit($sql, 1);
+		$idea_title = $this->db->sql_fetchfield('idea_title');
+		$this->db->sql_freeresult($result);
+
+		return $idea_title;
+	}
+
+	/**
 	 * Submits a vote on an idea.
 	 *
 	 * @param array $idea    The idea returned by get_idea().

--- a/factory/ideas.php
+++ b/factory/ideas.php
@@ -266,6 +266,34 @@ class ideas
 	}
 
 	/**
+	 * Do a live search on idea titles. Return any matches based on a given search query.
+	 *
+	 * @param string $search The string of characters to search using LIKE
+	 * @param int    $limit  The number of results to return
+	 * @return array An array of matching idea id/key and title/values
+	 */
+	public function ideas_title_livesearch($search, $limit = 10)
+	{
+		$results = [];
+		$sql = 'SELECT idea_title, idea_id
+			FROM ' . $this->table_ideas . '
+			WHERE idea_title ' . $this->db->sql_like_expression($search . $this->db->get_any_char());
+		$result = $this->db->sql_query_limit($sql, $limit);
+		while ($row = $this->db->sql_fetchrow($result))
+		{
+			$results[] = [
+				'idea_id'     => $row['idea_id'],
+				'result'      => $row['idea_id'],
+				'clean_title' => $row['idea_title'],
+				'display'     => "<span>{$row['idea_title']}</span>",
+			];
+		}
+		$this->db->sql_freeresult($result);
+
+		return $results;
+	}
+
+	/**
 	 * Returns the status name from the status ID specified.
 	 *
 	 * @param int $id ID of the status.

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -30,6 +30,7 @@ $lang = array_merge($lang, array(
 	'DATE'					=> 'Date',
 	'DELETE_IDEA'			=> 'Delete idea',
 	'DUPLICATE'				=> 'Duplicate',
+	'DUPLICATE_PLACEHOLDER'	=> 'Start typing a title',
 
 	'EDIT'					=> 'Edit',
 	'ENABLE_JS'             => 'Please enable JavaScript in your browser to use phpBB Ideas effectively.',
@@ -38,7 +39,6 @@ $lang = array_merge($lang, array(
 	'IDEA_DELETED'			=> 'Idea successfully deleted.',
 	'IDEA_ID'				=> 'Idea ID',
 	'IDEA_LIST'				=> 'Idea List',
-	'IDEA_NUM'				=> 'Idea #',
 	'IDEA_NOT_FOUND'		=> 'Idea not found',
 	'IDEA_STORED_MOD'		=> 'Your idea has been submitted successfully, but it will need to be approved by a moderator before it is publicly viewable. You will be notified when your idea has been approved.<br /><br /><a href="%s">Return to Ideas</a>.',
 	'IDEAS_TITLE'			=> 'phpBB Ideas',
@@ -78,7 +78,7 @@ $lang = array_merge($lang, array(
 
 	'TICKET'				=> 'Ticket',
 	'TICKET_ERROR'			=> 'Ticket ID must be of the format “PHPBB3-#####”.',
-	'TICKET_ERROR_DUP'		=> 'Please use the Idea ID number.',
+	'TICKET_ERROR_DUP'		=> 'You must click on an idea title from the live search results. To delete the duplicate, clear the field and hit ENTER. To exit this field click ESC.',
 	'TITLE'					=> 'Title',
 	'TITLE_TOO_LONG'		=> 'Subject must be under %d characters long.',
 	'TITLE_TOO_SHORT'		=> 'You must specify a subject when posting a new idea.',

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -78,7 +78,7 @@ $lang = array_merge($lang, array(
 
 	'TICKET'				=> 'Ticket',
 	'TICKET_ERROR'			=> 'Ticket ID must be of the format “PHPBB3-#####”.',
-	'TICKET_ERROR_DUP'		=> 'You must click on an idea title from the live search results. To delete the duplicate, clear the field and hit ENTER. To exit this field click ESC.',
+	'TICKET_ERROR_DUP'		=> 'You must click on an idea title from the live search results. To delete the duplicate, clear the field and press ENTER. To exit this field press ESC.',
 	'TITLE'					=> 'Title',
 	'TITLE_TOO_LONG'		=> 'Subject must be under %d characters long.',
 	'TITLE_TOO_SHORT'		=> 'You must specify a subject when posting a new idea.',

--- a/migrations/m10_update_idea_schema.php
+++ b/migrations/m10_update_idea_schema.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ *
+ * Ideas extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\ideas\migrations;
+
+class m10_update_idea_schema extends \phpbb\db\migration\migration
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	static public function depends_on()
+	{
+		return [
+			'\phpbb\ideas\migrations\m1_initial_schema',
+			'\phpbb\ideas\migrations\m6_migrate_old_tables',
+			'\phpbb\ideas\migrations\m7_drop_old_tables',
+			'\phpbb\ideas\migrations\m8_implemented_version',
+			'\phpbb\ideas\migrations\m9_remove_idea_bot',
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Convert ideas title column to sortable text (same as topic titles)
+	 * to allow for case-insensitive SQL LIKE searches.
+	 */
+	public function update_schema()
+	{
+		return [
+			'change_columns' => [
+				$this->table_prefix . 'ideas_ideas' => [
+					'idea_title' => ['STEXT_UNI', '', 'true_sort'],
+				],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function revert_schema()
+	{
+	}
+}

--- a/styles/prosilver/template/idea_body.html
+++ b/styles/prosilver/template/idea_body.html
@@ -90,10 +90,33 @@
 			{% if IDEA_DUPLICATE or S_IS_MOD %}
 				<dt class="duplicatetoggle idealabel"{% if IDEA_STATUS_ID != STATUS_ARY.DUPLICATE %} style="display:none"{% endif %}>{{ lang('DUPLICATE') ~ lang('COLON') }}</dt>
 				<dd class="duplicatetoggle" {% if IDEA_STATUS_ID != STATUS_ARY.DUPLICATE %}style="display:none"{% endif %}>
-					<a id="duplicatelink" data-link="{{ U_IDEA_DUPLICATE }}" data-l-msg="{{ lang('IDEA_NUM') }}" {% if IDEA_DUPLICATE %}href="{{ U_IDEA_DUPLICATE }}">{{ lang('IDEA_NUM') ~ IDEA_DUPLICATE }}{% else %}style="display:none">{% endif %}</a>
+					<a id="duplicatelink" data-link="{{ U_IDEA_DUPLICATE }}" {% if IDEA_DUPLICATE %}href="{{ U_IDEA_DUPLICATE }}">{{ IDEA_DUPLICATE }}{% else %}style="display:none">{% endif %}</a>
 					{% if S_IS_MOD %}
 						<a href="{{ U_EDIT_DUPLICATE }}" id="duplicateedit" data-l-add="{{ lang('ADD') }}" data-l-edit="{{ lang('EDIT') }}">{% if IDEA_DUPLICATE %}<i class="icon fa-fw fa-pencil"></i>{{ lang('EDIT') }}{% else %}<i class="icon fa-fw fa-plus-circle"></i>{{ lang('ADD') }}{% endif %}</a>
-						<input type="text" id="duplicateeditinput" class="ideainput"{% if IDEA_DUPLICATE %} value="{{ IDEA_DUPLICATE }}"{% endif %} placeholder="###" data-l-err="{{ lang('ERROR') }}" data-l-msg="{{ lang('TICKET_ERROR_DUP') }}" />
+						<div class="dropdown-container dropdown-{{ S_CONTENT_FLOW_END }}">
+							<input
+								type="text"
+								name="duplicateeditinput"
+								id="duplicateeditinput"
+								value="{{ IDEA_DUPLICATE ? IDEA_DUPLICATE }}"
+								placeholder="{{ lang('DUPLICATE_PLACEHOLDER') }}"
+								class="ideainput"
+								autocomplete="off"
+								data-filter="phpbb.search.filter"
+								data-ajax="idea_search"
+								data-min-length="3"
+								data-url="{{ U_TITLE_LIVESEARCH }}"
+								data-results="#live-search"
+								data-l-err="{{ lang('ERROR') }}"
+								data-l-msg="{{ lang('TICKET_ERROR_DUP') }}"
+							/>
+							<div class="dropdown live-search hidden" id="live-search">
+								<div class="pointer"><div class="pointer-inner"></div></div>
+								<ul class="dropdown-contents search-results">
+									<li class="search-result-tpl"><span class="search-result"></span></li>
+								</ul>
+							</div>
+						</div>
 					{% endif %}
 				</dd>
 			{% endif %}


### PR DESCRIPTION
Converts from the old and cumbersome way of linking duplicate by their Idea ID#:
![duplicateold](https://user-images.githubusercontent.com/303711/82388264-08600c80-99ee-11ea-8acd-ce24d849c5a7.gif)

To using the Idea Titles using live search with immediate clickable results:
![DuplicateLinks](https://user-images.githubusercontent.com/303711/82388295-2463ae00-99ee-11ea-96e4-8859522cad96.gif)
