### PR TITLE
Hot fix for cleaning old ideas

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -128,7 +128,7 @@ class listener implements EventSubscriberInterface
 
 			// This freakish looking regex pattern should
 			// remove the old ideas link-backs from the message.
-			$message = preg_replace('/(<br[^>]*>\\n?)\\1-{10}\\1\\1.*]/s', '', $message);
+			$message = preg_replace('/(<br[^>]*>\\n?)?\\1?-{10}\\1?\\1?.*]/s', '', $message);
 
 			$post_row['MESSAGE'] = $message;
 			$event['post_row'] = $post_row;


### PR DESCRIPTION
Noticed old ideas junk, links to nonexistent ideas left over from the phpBB 3.0 ideas are not being cleaned out of the ideas on dot-com as they should be. This update to the regex should fix that. 

Here's an example of a broken Idea. https://www.phpbb.com/community/viewtopic.php?f=436&t=2190130

That junk starting with the dashes and everything after it in the first post should not be shown.