### PR TITLE
Continue patching the removal of old ideas gunk

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -82,7 +82,7 @@ class listener implements EventSubscriberInterface
 	{
 		return array(
 			'core.viewforum_get_topic_data'				=> 'ideas_forum_redirect',
-			'core.viewtopic_modify_post_row'			=> array(array('clean_message'), array('show_post_buttons')),
+			'core.viewtopic_modify_post_row'			=> 'show_post_buttons',
 			'core.viewtopic_modify_page_title'			=> 'show_idea',
 			'core.viewtopic_add_quickmod_option_before'	=> 'adjust_quickmod_tools',
 			'core.viewonline_overwrite_location'		=> 'viewonline_ideas',
@@ -104,31 +104,6 @@ class listener implements EventSubscriberInterface
 			// Use the custom base url if set, otherwise default to normal routing
 			$url = $this->config['ideas_base_url'] ?: $this->helper->route('phpbb_ideas_index_controller');
 			redirect($url);
-		}
-	}
-
-	/**
-	 * Clean obsolete link-backs from idea topics posted prior to Sep. 2017
-	 *
-	 * @param \phpbb\event\data $event The event object
-	 * @return void
-	 * @access public
-	 */
-	public function clean_message($event)
-	{
-		if (!$this->is_ideas_forum($event['row']['forum_id']))
-		{
-			return;
-		}
-
-		if ($this->is_first_post($event['topic_data']['topic_first_post_id'], $event['row']['post_id']) && $event['topic_data']['topic_time'] < strtotime('September 1, 2017'))
-		{
-			// This freakish looking regex pattern should remove the old ideas link-backs from the message.
-			$event->update_subarray(
-				'post_row',
-				'MESSAGE',
-				preg_replace('/(<br[^>]*>\\n?)?\\1?-{10}\\1?\\1?(?:(?!<\/[rt]>).)*/s', '', $event['post_row']['MESSAGE'])
-			);
 		}
 	}
 

--- a/event/listener.php
+++ b/event/listener.php
@@ -146,7 +146,7 @@ class listener implements EventSubscriberInterface
 			return;
 		}
 
-		if ($event['topic_data']['topic_first_post_id'] == $event['row']['post_id'])
+		if ($this->is_first_post($event['topic_data']['topic_first_post_id'], $event['row']['post_id']))
 		{
 			$event->update_subarray('post_row', 'U_DELETE', false);
 			$event->update_subarray('post_row', 'U_WARN', false);
@@ -333,9 +333,9 @@ class listener implements EventSubscriberInterface
 	public function edit_idea_title($event)
 	{
 		if ($event['mode'] !== 'edit' ||
-			$event['post_data']['topic_first_post_id'] != $event['post_id'] ||
 			!$event['update_subject'] ||
-			!$this->is_ideas_forum($event['forum_id']))
+			!$this->is_ideas_forum($event['forum_id']) ||
+			!$this->is_first_post($event['post_data']['topic_first_post_id'], $event['post_id']))
 		{
 			return;
 		}

--- a/migrations/m11_reparse_old_ideas.php
+++ b/migrations/m11_reparse_old_ideas.php
@@ -15,14 +15,6 @@ class m11_reparse_old_ideas extends \phpbb\db\migration\container_aware_migratio
 	/**
 	 * {@inheritDoc}
 	 */
-	public function effectively_installed()
-	{
-		return $this->config->offsetExists('phpbb.ideas.text_reparser.clean_old_ideas');
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
 	public static function depends_on()
 	{
 		return [
@@ -32,6 +24,17 @@ class m11_reparse_old_ideas extends \phpbb\db\migration\container_aware_migratio
 			'\phpbb\ideas\migrations\m8_implemented_version',
 			'\phpbb\ideas\migrations\m10_update_idea_schema',
 		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function effectively_installed()
+	{
+		/** @var \phpbb\textreparser\manager $reparser_manager */
+		$reparser_manager = $this->container->get('text_reparser.manager');
+
+		return !empty($reparser_manager->get_resume_data('phpbb.ideas.text_reparser.clean_old_ideas'));
 	}
 
 	/**

--- a/migrations/m11_reparse_old_ideas.php
+++ b/migrations/m11_reparse_old_ideas.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ *
+ * Ideas extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\ideas\migrations;
+
+class m11_reparse_old_ideas extends \phpbb\db\migration\container_aware_migration
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function effectively_installed()
+	{
+		return $this->config->offsetExists('phpbb.ideas.text_reparser.clean_old_ideas');
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function depends_on()
+	{
+		return [
+			'\phpbb\ideas\migrations\m1_initial_schema',
+			'\phpbb\ideas\migrations\m6_migrate_old_tables',
+			'\phpbb\ideas\migrations\m7_drop_old_tables',
+			'\phpbb\ideas\migrations\m8_implemented_version',
+			'\phpbb\ideas\migrations\m10_update_idea_schema',
+		];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function update_data()
+	{
+		return [
+			['custom', [[$this, 'reparse']]],
+		];
+	}
+
+	/**
+	 * Run the clean old ideas reparser
+	 *
+	 * @param int $current An idea identifier
+	 * @return bool|int An idea identifier or true if finished
+	 */
+	public function reparse($current = 0)
+	{
+		/** @var \phpbb\textreparser\manager $reparser_manager */
+		$reparser_manager = $this->container->get('text_reparser.manager');
+
+		/** @var \phpbb\textformatter\s9e\utils $text_formatter_utils */
+		$text_formatter_utils = $this->container->get('text_formatter.utils');
+
+		$reparser = new \phpbb\ideas\textreparser\plugins\clean_old_ideas(
+			$this->db,
+			$text_formatter_utils,
+			$this->container->getParameter('tables.posts'),
+			$this->container->getParameter('tables.topics'),
+			$this->container->getParameter('core.table_prefix') . 'ideas_ideas'
+		);
+
+		if (empty($current))
+		{
+			$current = $reparser->get_max_id();
+		}
+
+		$limit = 50; // lets keep the reparsing conservative
+		$start = max(1, $current + 1 - $limit);
+		$end   = max(1, $current);
+
+		$reparser->reparse_range($start, $end);
+
+		$current = $start - 1;
+
+		if ($current === 0)
+		{
+			// Prevent CLI command from running this reparser again
+			$reparser_manager->update_resume_data('phpbb.ideas.text_reparser.clean_old_ideas', 1, 0, $limit);
+
+			return true;
+		}
+
+		return $current;
+	}
+}

--- a/migrations/m11_reparse_old_ideas.php
+++ b/migrations/m11_reparse_old_ideas.php
@@ -34,7 +34,7 @@ class m11_reparse_old_ideas extends \phpbb\db\migration\container_aware_migratio
 		/** @var \phpbb\textreparser\manager $reparser_manager */
 		$reparser_manager = $this->container->get('text_reparser.manager');
 
-		return !empty($reparser_manager->get_resume_data('phpbb.ideas.text_reparser.clean_old_ideas'));
+		return !empty($reparser_manager->get_resume_data('phpbb.ideas.text_reparser.clean_old_ideas') || !$this->bbcode_exists('idea'));
 	}
 
 	/**
@@ -91,5 +91,24 @@ class m11_reparse_old_ideas extends \phpbb\db\migration\container_aware_migratio
 		}
 
 		return $current;
+	}
+
+	/**
+	 * Check if a bbcode exists
+	 *
+	 * @param  string $tag BBCode's tag
+	 * @return bool        True if bbcode exists, false if not
+	 */
+	public function bbcode_exists($tag)
+	{
+		$sql = 'SELECT bbcode_id
+			FROM ' . $this->table_prefix . "bbcodes
+			WHERE LOWER(bbcode_tag) = '" . $this->db->sql_escape(strtolower($tag)) . "'
+			OR LOWER(bbcode_tag) = '" . $this->db->sql_escape(strtolower($tag)) . "='";
+		$result = $this->db->sql_query_limit($sql, 1);
+		$bbcode_id = $this->db->sql_fetchfield('bbcode_id');
+		$this->db->sql_freeresult($result);
+
+		return $bbcode_id !== false;
 	}
 }

--- a/tests/event/listener_test.php
+++ b/tests/event/listener_test.php
@@ -119,46 +119,6 @@ class listener_test extends \phpbb_test_case
 	}
 
 	/**
-	 * Data set for test_clean_message
-	 *
-	 * @return array Array of test data
-	 */
-	public function clean_message_data()
-	{
-		return array(
-			array(1, 1, 1, 'Foo Bar', 'Foo Bar'), // Invalid forum, nothing cleaned
-			array(2, 1, 2, 'Foo Bar', 'Foo Bar'), // Invalid post, nothing clean
-			array(2, 1, 1, 'Foo Bar', 'Foo Bar'), // Valid post, nothing to clean
-			array(2, 1, 1, 'Foo Bar<br />----------<br>BarFoo<br>', 'Foo Bar'), // Valid post, requires cleaning
-			array(2, 1, 1, 'Foo Bar<br />\n\n----------<br>\nBarFoo<br>', 'Foo Bar'), // Valid post, requires cleaning
-			array(2, 1, 1, 'Foo Bar<br />--------<br>BarFoo<br>', 'Foo Bar<br />--------<br>BarFoo<br>'), // Valid post, nothing to clean
-		);
-	}
-
-	/**
-	 * Test the clean_message event
-	 *
-	 * @dataProvider clean_message_data
-	 */
-	public function test_clean_message($forum_id, $post_id, $first_post_id, $message, $expected)
-	{
-		$listener = $this->get_listener();
-
-		$event = new \phpbb\event\data(array(
-			'row' 			=> array(
-				'forum_id'	=> $forum_id,
-				'post_id'	=> $post_id,
-			),
-			'post_row'		=> array('MESSAGE' => $message),
-			'topic_data'	=> array('topic_first_post_id' => $first_post_id),
-		));
-
-		$listener->clean_message($event);
-
-		$this->assertContains($expected, $event['post_row']['MESSAGE']);
-	}
-
-	/**
 	 * Data set for show_post_buttons
 	 *
 	 * @return array Array of test data

--- a/tests/textreparser/clean_old_ideas_test.php
+++ b/tests/textreparser/clean_old_ideas_test.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ *
+ * Ideas extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\ideas\tests\textreparser;
+
+include_once __DIR__ . '/../../../../../../tests/text_reparser/plugins/test_row_based_plugin.php';
+
+class clean_old_ideas_test extends \phpbb_textreparser_test_row_based_plugin
+{
+	protected static function setup_extensions()
+	{
+		return array('phpbb/ideas');
+	}
+
+	public function getDataSet()
+	{
+		return $this->createXMLDataSet(__DIR__ . '/fixtures/ideas.xml');
+	}
+
+	protected function get_reparser()
+	{
+		return new \phpbb\ideas\textreparser\plugins\clean_old_ideas(
+			$this->db,
+			new \phpbb\textformatter\s9e\utils(),
+			'phpbb_posts',
+			'phpbb_topics',
+			'phpbb_ideas_ideas'
+		);
+	}
+
+	public function get_reparse_tests()
+	{
+		return [
+			[
+				1,
+				5,
+				[
+					[
+						'id'   => '100',
+						'text' => 'This post has nothing to change',
+					],
+					[
+						'id'   => '200',
+						'text' => '<r>This post is too new to be cleaned<IDEA idea="1000"><s>[idea=1000]</s>Linked Idea<e>[/idea]</e></IDEA><USER user="1000"><s>[user=1000]</s>testuser<e>[/user]</e></USER></r>',
+					],
+					[
+						'id'   => '300',
+						'text' => '<r>This post should be cleaned</r>',
+					],
+					[
+						'id'   => '400',
+						'text' => '<r>This post is a reply and should not be changed<IDEA idea="1000"><s>[idea=1000]</s>Linked Idea<e>[/idea]</e></IDEA><USER user="1000"><s>[user=1000]</s>testuser<e>[/user]</e></USER></r>',
+					],
+					[
+						'id'   => '101010',
+						'text' => '<r>This post is out of range<IDEA idea="1000"><s>[idea=1000]</s>Linked Idea<e>[/idea]</e></IDEA><USER user="1000"><s>[user=1000]</s>testuser<e>[/user]</e></USER></r>',
+					],
+				]
+			],
+		];
+	}
+}

--- a/tests/textreparser/fixtures/ideas.xml
+++ b/tests/textreparser/fixtures/ideas.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+	<table name="phpbb_posts">
+		<column>post_id</column>
+		<column>post_text</column>
+		<column>post_time</column>
+		<column>topic_id</column>
+		<row>
+			<value>100</value>
+			<value>This post has nothing to change</value>
+			<value>1402532621</value>
+			<value>11</value>
+		</row>
+		<row>
+			<value>200</value>
+			<value><![CDATA[<r>This post is too new to be cleaned<IDEA idea="1000"><s>[idea=1000]</s>Linked Idea<e>[/idea]</e></IDEA><USER user="1000"><s>[user=1000]</s>testuser<e>[/user]</e></USER></r>]]></value>
+			<value>1577836800</value>
+			<value>22</value>
+		</row>
+		<row>
+			<value>300</value>
+			<value><![CDATA[<r>This post should be cleaned<br/>
+<br/>
+----------<br/>
+<br/>
+View idea at: <IDEA idea="1000"><s>[idea=1000]</s>Linked Idea<e>[/idea]</e></IDEA><br/>
+<br/>
+Posted by <USER user="1000"><s>[user=1000]</s>testuser<e>[/user]</e></USER></r>]]></value>
+			<value>1402532621</value>
+			<value>33</value>
+		</row>
+		<row>
+			<value>400</value>
+			<value><![CDATA[<r>This post is a reply and should not be changed<IDEA idea="1000"><s>[idea=1000]</s>Linked Idea<e>[/idea]</e></IDEA><USER user="1000"><s>[user=1000]</s>testuser<e>[/user]</e></USER></r>]]></value>
+			<value>1402532621</value>
+			<value>33</value>
+		</row>
+		<row>
+			<value>101010</value>
+			<value><![CDATA[<r>This post is out of range<IDEA idea="1000"><s>[idea=1000]</s>Linked Idea<e>[/idea]</e></IDEA><USER user="1000"><s>[user=1000]</s>testuser<e>[/user]</e></USER></r>]]></value>
+			<value>1402532621</value>
+			<value>1010</value>
+		</row>
+	</table>
+	<table name="phpbb_topics">
+		<column>topic_id</column>
+		<column>topic_first_post_id</column>
+		<row>
+			<value>11</value>
+			<value>100</value>
+		</row>
+		<row>
+			<value>22</value>
+			<value>200</value>
+		</row>
+		<row>
+			<value>33</value>
+			<value>300</value>
+		</row>
+		<row>
+			<value>1010</value>
+			<value>101010</value>
+		</row>
+	</table>
+	<table name="phpbb_ideas_ideas">
+		<column>idea_id</column>
+		<column>topic_id</column>
+		<row>
+			<value>1</value>
+			<value>11</value>
+		</row>
+		<row>
+			<value>2</value>
+			<value>22</value>
+		</row>
+		<row>
+			<value>3</value>
+			<value>33</value>
+		</row>
+		<row>
+			<value>1000</value>
+			<value>1010</value>
+		</row>
+	</table>
+</dataset>

--- a/textreparser/plugins/clean_old_ideas.php
+++ b/textreparser/plugins/clean_old_ideas.php
@@ -101,7 +101,11 @@ class clean_old_ideas extends \phpbb\textreparser\row_based_plugin
 		$text = $this->text_formatter_utils->remove_bbcode($text, 'idea');
 
 		// Remove old strings from the idea post
-		$text = str_replace(['----------', 'View idea at: ', 'Posted by '], ['', '', ''], $text);
+		$text = str_replace([
+			"<br/>\n<br/>\n----------",
+			"<br/>\n<br/>\nView idea at: ",
+			"<br/>\n<br/>\nPosted by "
+		], ['', '', ''], $text);
 
 		// Save the new text if it has changed and it's not a dry run
 		if ($text !== $record['text'] && $this->save_changes)

--- a/textreparser/plugins/clean_old_ideas.php
+++ b/textreparser/plugins/clean_old_ideas.php
@@ -70,13 +70,14 @@ class clean_old_ideas extends \phpbb\textreparser\row_based_plugin
 	{
 		$columns = $this->get_columns();
 
+		$fields = [];
 		foreach ($columns as $field_name => $column_name)
 		{
 			$fields[] = 'p.' . $column_name . ' AS ' . $field_name;
 		}
 
-		// Get the the first post's text for ideas created prior to Sep. 2017
-		$sql = 'SELECT ' . implode(', ', $fields) . '
+		// Query the first post's text for ideas created prior to Sep. 2017
+		return 'SELECT ' . implode(', ', $fields) . '
 			FROM ' . $this->table . ' p
 			INNER JOIN ' . $this->ideas_table . ' i
 				ON i.topic_id = p.topic_id
@@ -84,8 +85,6 @@ class clean_old_ideas extends \phpbb\textreparser\row_based_plugin
 				ON p.' . $columns['id'] . ' = t.topic_first_post_id
 			WHERE i.idea_date < ' . strtotime('September 1, 2017') . '
 				AND  i.idea_id BETWEEN ' . $min_id . ' AND ' . $max_id;
-
-		return $sql;
 	}
 
 	/**

--- a/textreparser/plugins/clean_old_ideas.php
+++ b/textreparser/plugins/clean_old_ideas.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ *
+ * Ideas extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\ideas\textreparser\plugins;
+
+class clean_old_ideas extends \phpbb\textreparser\row_based_plugin
+{
+	/** @var \phpbb\textformatter\s9e\utils */
+	protected $text_formatter_utils;
+
+	/** @var string */
+	protected $ideas_table;
+
+	/** @var string  */
+	protected $topics_table;
+
+	/**
+	 * Constructor
+	 *
+	 * @param \phpbb\db\driver\driver_interface $db                   Database connection
+	 * @param \phpbb\textformatter\s9e\utils    $text_formatter_utils Text formatter utilities object
+	 * @param string                            $table                Posts Table
+	 * @param string                            $topics_table         Topics Table
+	 * @param string                            $ideas_table          Ideas Table
+	 */
+	public function __construct(\phpbb\db\driver\driver_interface $db, \phpbb\textformatter\s9e\utils $text_formatter_utils, $table, $topics_table, $ideas_table)
+	{
+		parent::__construct($db, $table);
+
+		$this->text_formatter_utils = $text_formatter_utils;
+		$this->ideas_table = $ideas_table;
+		$this->topics_table = $topics_table;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_columns()
+	{
+		return [
+			'id'   => 'post_id',
+			'text' => 'post_text',
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function get_max_id()
+	{
+		$sql = 'SELECT MAX(idea_id) AS max_id FROM ' . $this->ideas_table;
+		$result = $this->db->sql_query($sql);
+		$max_id = (int) $this->db->sql_fetchfield('max_id');
+		$this->db->sql_freeresult($result);
+
+		return $max_id;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function get_records_by_range_query($min_id, $max_id)
+	{
+		$columns = $this->get_columns();
+
+		foreach ($columns as $field_name => $column_name)
+		{
+			$fields[] = 'p.' . $column_name . ' AS ' . $field_name;
+		}
+
+		// Get the the first post's text for ideas created prior to Sep. 2017
+		$sql = 'SELECT ' . implode(', ', $fields) . '
+			FROM ' . $this->table . ' p
+			INNER JOIN ' . $this->ideas_table . ' i
+				ON i.topic_id = p.topic_id
+			INNER JOIN ' . $this->topics_table . ' t
+				ON p.' . $columns['id'] . ' = t.topic_first_post_id
+			WHERE i.idea_date < ' . strtotime('September 1, 2017') . '
+				AND  i.idea_id BETWEEN ' . $min_id . ' AND ' . $max_id;
+
+		return $sql;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function reparse_record(array $record)
+	{
+		$text = $record['text'];
+
+		// Remove the USER bbcode from the idea post
+		$text = $this->text_formatter_utils->remove_bbcode($text, 'user');
+
+		// Remove the IDEA bbcode from the idea post
+		$text = $this->text_formatter_utils->remove_bbcode($text, 'idea');
+
+		// Remove old strings from the idea post
+		$text = str_replace(['----------', 'View idea at: ', 'Posted by '], ['', '', ''], $text);
+
+		// Save the new text if it has changed and it's not a dry run
+		if ($text !== $record['text'] && $this->save_changes)
+		{
+			$record['text'] = $text;
+			$this->save_record($record);
+		}
+	}
+}

--- a/textreparser/plugins/clean_old_ideas.php
+++ b/textreparser/plugins/clean_old_ideas.php
@@ -83,7 +83,7 @@ class clean_old_ideas extends \phpbb\textreparser\row_based_plugin
 				ON i.topic_id = p.topic_id
 			INNER JOIN ' . $this->topics_table . ' t
 				ON p.' . $columns['id'] . ' = t.topic_first_post_id
-			WHERE i.idea_date < ' . strtotime('September 1, 2017') . '
+			WHERE p.post_time < ' . strtotime('September 1, 2017') . '
 				AND  i.idea_id BETWEEN ' . $min_id . ' AND ' . $max_id;
 	}
 


### PR DESCRIPTION
There are 2 ways to go with this PR:

1. ~~We stick with the event listener that removes (on the fly) old Ideas Mod junk from the first post of old ideas. If we stick with this, we should remove the new files added that enable option 2 below...~~

2. We use a migration to permanently cleanse the old ideas of their old Mod junk. If we go this direction we should remove the event listener (option 1) that does the same work on the fly.