### PR TITLE
View Your Ideas Quick Link

### DIFF
--- a/controller/base.php
+++ b/controller/base.php
@@ -144,5 +144,6 @@ abstract class base
 			'S_SEARCHBOX_ACTION'	=> append_sid("{$this->root_path}search.{$this->php_ext}"),
 			'S_SEARCH_IDEAS_HIDDEN_FIELDS'	=> build_hidden_fields(array('fid' => array($this->config['ideas_forum_id']))),
 		));
+			'U_SEARCH_MY_IDEAS' 	=> $this->helper->route('phpbb_ideas_list_controller', ['sort' => ideas::SORT_MYIDEAS, 'status' => '-1']),
 	}
 }

--- a/controller/base.php
+++ b/controller/base.php
@@ -133,17 +133,18 @@ abstract class base
 	}
 
 	/**
-	 * Assign template variables for a search ideas field
+	 * Assign common template variables for Ideas pages
 	 *
 	 * @return void
 	 */
-	protected function display_search_ideas()
+	protected function display_common_vars()
 	{
-		$this->template->assign_vars(array(
+		$this->template->assign_vars([
 			'S_DISPLAY_SEARCHBOX'	=> (bool) $this->auth->acl_get('u_search') && $this->auth->acl_get('f_search', $this->config['ideas_forum_id']) && $this->config['load_search'],
 			'S_SEARCHBOX_ACTION'	=> append_sid("{$this->root_path}search.{$this->php_ext}"),
-			'S_SEARCH_IDEAS_HIDDEN_FIELDS'	=> build_hidden_fields(array('fid' => array($this->config['ideas_forum_id']))),
-		));
+			'S_SEARCH_IDEAS_HIDDEN_FIELDS'	=> build_hidden_fields(['fid' => [$this->config['ideas_forum_id']]]),
+
 			'U_SEARCH_MY_IDEAS' 	=> $this->helper->route('phpbb_ideas_list_controller', ['sort' => ideas::SORT_MYIDEAS, 'status' => '-1']),
+		]);
 	}
 }

--- a/controller/idea_controller.php
+++ b/controller/idea_controller.php
@@ -12,6 +12,7 @@ namespace phpbb\ideas\controller;
 
 use phpbb\exception\http_exception;
 use phpbb\ideas\factory\ideas;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class idea_controller extends base
@@ -24,7 +25,7 @@ class idea_controller extends base
 	 *
 	 * @param $idea_id int The ID of the requested idea, maybe?
 	 * @throws http_exception
-	 * @return \Symfony\Component\HttpFoundation\Response A Symfony Response object
+	 * @return JsonResponse|RedirectResponse
 	 */
 	public function idea($idea_id)
 	{
@@ -44,7 +45,7 @@ class idea_controller extends base
 		{
 			$result = $this->$mode();
 
-			return new \Symfony\Component\HttpFoundation\JsonResponse($result);
+			return new JsonResponse($result);
 		}
 
 		$params = array(

--- a/controller/index_controller.php
+++ b/controller/index_controller.php
@@ -57,8 +57,8 @@ class index_controller extends base
 			'FORUM_NAME'		=> $this->language->lang('IDEAS'),
 		));
 
-		// Display the search ideas field
-		$this->display_search_ideas();
+		// Display common ideas template vars
+		$this->display_common_vars();
 
 		return $this->helper->render('index_body.html', $this->language->lang('IDEAS_TITLE'));
 	}

--- a/controller/index_controller.php
+++ b/controller/index_controller.php
@@ -43,9 +43,9 @@ class index_controller extends base
 		$this->assign_template_block_vars('implemented_ideas', $ideas);
 
 		$this->template->assign_vars(array(
-			'U_VIEW_TOP'		=> $this->link_helper->get_list_link(ideas::SORT_TOP),
-			'U_VIEW_LATEST'		=> $this->link_helper->get_list_link(ideas::SORT_NEW),
-			'U_VIEW_IMPLEMENTED'=> $this->link_helper->get_list_link(ideas::SORT_IMPLEMENTED),
+			'U_VIEW_TOP'		=> $this->helper->route('phpbb_ideas_list_controller', ['sort' => ideas::SORT_TOP]),
+			'U_VIEW_LATEST'		=> $this->helper->route('phpbb_ideas_list_controller', ['sort' => ideas::SORT_NEW]),
+			'U_VIEW_IMPLEMENTED'=> $this->helper->route('phpbb_ideas_list_controller', ['sort' => ideas::SORT_DATE, 'status' => ideas::$statuses['IMPLEMENTED']]),
 			'U_POST_ACTION'		=> $this->helper->route('phpbb_ideas_post_controller'),
 			'U_MCP' 			=> ($this->auth->acl_get('m_', $this->config['ideas_forum_id'])) ? append_sid("{$this->root_path}mcp.{$this->php_ext}", "f={$this->config['ideas_forum_id']}&amp;i=main&amp;mode=forum_view", true, $this->user->session_id) : '',
 

--- a/controller/list_controller.php
+++ b/controller/list_controller.php
@@ -52,22 +52,16 @@ class list_controller extends base
 			$sort = ideas::SORT_DATE;
 		}
 
-		// if sort by "implemented", sort ideas with status implemented by date
-		if ($sort === ideas::SORT_IMPLEMENTED)
-		{
-			$status = ideas::$statuses['IMPLEMENTED'];
-			$sort = ideas::SORT_DATE;
-		}
-
-		// Set the status name for displaying in the template
-		$status_name = (!$status && $sort === ideas::SORT_TOP) ? $this->language->lang('TOP_IDEAS') : $this->ideas->get_status_from_id($status);
+		// Set the name for displaying in the template
+		$status_name = 'LIST_' . strtoupper($status > 0 ? array_search($status, ideas::$statuses) : $sort);
+		$status_name = $this->language->is_set($status_name) ? $this->language->lang($status_name) : '';
 
 		// For special case where we want to request ALL ideas,
 		// including the statuses normally hidden from lists.
 		if ($status === -1)
 		{
 			$status = ideas::$statuses;
-			$status_name = $this->language->lang('ALL_IDEAS');
+			$status_name = $status_name ?: $this->language->lang('ALL_IDEAS');
 		}
 
 		// Generate ideas

--- a/controller/list_controller.php
+++ b/controller/list_controller.php
@@ -112,8 +112,8 @@ class list_controller extends base
 			$start
 		);
 
-		// Display the search ideas field
-		$this->display_search_ideas();
+		// Display common ideas template vars
+		$this->display_common_vars();
 
 		return $this->helper->render('list_body.html', $this->language->lang('IDEA_LIST'));
 	}

--- a/event/listener.php
+++ b/event/listener.php
@@ -223,7 +223,8 @@ class listener implements EventSubscriberInterface
 			'U_REMOVE_VOTE'		=> $this->link_helper->get_idea_link($idea['idea_id'], 'removevote', true),
 			'U_IDEA_VOTE'		=> $this->link_helper->get_idea_link($idea['idea_id'], 'vote', true),
 			'U_IDEA_DUPLICATE'	=> $this->link_helper->get_idea_link($idea['duplicate_id']),
-			'U_IDEA_STATUS_LINK'=> $this->helper->route('phpbb_ideas_list_controller', array('status' => $idea['idea_status'])),
+			'U_IDEA_STATUS_LINK'=> $this->helper->route('phpbb_ideas_list_controller', ['status' => $idea['idea_status']]),
+			'U_SEARCH_MY_IDEAS' => $this->helper->route('phpbb_ideas_list_controller', ['sort' => ideas::SORT_MYIDEAS, 'status' => '-1']),
 			'U_TITLE_LIVESEARCH'=> $this->helper->route('phpbb_ideas_livesearch_controller'),
 		));
 

--- a/factory/ideas.php
+++ b/factory/ideas.php
@@ -222,17 +222,18 @@ class ideas
 	}
 
 	/**
-	 * Update $sql property with additional SQL statements that will filter
-	 * the query to get ideas within or without certain statuses.
+	 * Update $sql property with additional SQL statements to filter ideas
+	 * by status. If $status is given we'll get those ideas. If no $status
+	 * is given, the default is to get all ideas excluding Duplicates, Invalid
+	 * and Implemented statuses (because they are considered done & dusted,
+	 * if they were gases they'd be inert).
 	 *
-	 * @param array|int $status The id of the status(es) to load
+	 * @param array|int $status The id(s) of the status(es) to load
 	 *
 	 * @return \phpbb\ideas\factory\ideas $this For chaining calls
 	 */
 	protected function query_status($status = [])
 	{
-		// If we are given some statuses, get ideas from those. Otherwise the default is
-		// to get ideas excluding Duplicates, Invalid and Implemented statuses.
 		$this->sql['WHERE'][] = !empty($status) ? $this->db->sql_in_set('i.idea_status', $status) : $this->db->sql_in_set(
 			'i.idea_status', [self::$statuses['IMPLEMENTED'], self::$statuses['DUPLICATE'], self::$statuses['INVALID'],
 		], true);

--- a/factory/ideas.php
+++ b/factory/ideas.php
@@ -26,6 +26,7 @@ class ideas
 	const SORT_TITLE = 'title';
 	const SORT_TOP = 'top';
 	const SORT_VOTES = 'votes';
+	const SORT_MYIDEAS = 'egosearch';
 	const SUBJECT_LENGTH = 120;
 
 	/** @var array Idea status names and IDs */
@@ -196,6 +197,11 @@ class ideas
 
 			case self::SORT_VOTES:
 				$this->sql['ORDER_BY'] = 'i.idea_votes_up + i.idea_votes_down ' . $direction;
+			break;
+
+			case self::SORT_MYIDEAS:
+				$this->sql['WHERE'][] = 'i.idea_author = ' . (int) $this->user->data['user_id'];
+				$this->sql['ORDER_BY'] = "i.idea_date DESC";
 			break;
 
 			case self::SORT_TOP:

--- a/factory/ideas.php
+++ b/factory/ideas.php
@@ -21,7 +21,6 @@ class ideas
 {
 	const SORT_AUTHOR = 'author';
 	const SORT_DATE = 'date';
-	const SORT_IMPLEMENTED = 'implemented';
 	const SORT_NEW = 'new';
 	const SORT_SCORE = 'score';
 	const SORT_TITLE = 'title';

--- a/factory/linkhelper.php
+++ b/factory/linkhelper.php
@@ -50,19 +50,6 @@ class linkhelper
 	}
 
 	/**
-	 * Get the ideas list controller URL
-	 *
-	 * @param string $sort Optional value to sort the list by (top, new, date, etc.)
-	 * @return string The route
-	 */
-	public function get_list_link($sort = 'date')
-	{
-		return $this->helper->route('phpbb_ideas_list_controller', array(
-			'sort' => $sort,
-		));
-	}
-
-	/**
 	 * Returns a link to the users profile, complete with colour.
 	 *
 	 * Is there a function that already does this? This seems fairly database heavy.

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -55,6 +55,14 @@ $lang = array_merge($lang, array(
 	'JS_DISABLED'           => 'JavaScript is disabled',
 
 	'LATEST_IDEAS'			=> 'Latest Ideas',
+	'LIST_DUPLICATE'  		=> 'Duplicate ideas',
+	'LIST_EGOSEARCH'		=> 'My ideas',
+	'LIST_IMPLEMENTED' 		=> 'Implemented ideas',
+	'LIST_IN_PROGRESS' 		=> 'In Progress ideas',
+	'LIST_INVALID'    		=> 'Invalid ideas',
+	'LIST_NEW'				=> 'New ideas',
+	'LIST_TOP'				=> 'Top ideas',
+
 	'LOGGED_OUT'			=> 'You must be logged in to do this.',
 
 	'NEW'					=> 'New',

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -49,6 +49,7 @@ $lang = array_merge($lang, array(
 	'IMPLEMENTED_VERSION'	=> 'phpBB version',
 	'IN_PROGRESS'           => 'In Progress',
 	'INVALID'				=> 'Invalid',
+	'INVALID_IDEA_QUERY'	=> 'Invalid SQL query. Ideas failed to load.',
 	'INVALID_VOTE'			=> 'Invalid vote; the number you entered was invalid.',
 
 	'JS_DISABLED'           => 'JavaScript is disabled',

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -55,11 +55,11 @@ $lang = array_merge($lang, array(
 	'JS_DISABLED'           => 'JavaScript is disabled',
 
 	'LATEST_IDEAS'			=> 'Latest Ideas',
-	'LIST_DUPLICATE'  		=> 'Duplicate ideas',
-	'LIST_EGOSEARCH'		=> 'My ideas',
-	'LIST_IMPLEMENTED' 		=> 'Implemented ideas',
-	'LIST_IN_PROGRESS' 		=> 'In Progress ideas',
-	'LIST_INVALID'    		=> 'Invalid ideas',
+	'LIST_DUPLICATE'		=> 'Duplicate ideas',
+	'LIST_EGOSEARCH'		=> 'Your ideas',
+	'LIST_IMPLEMENTED'		=> 'Implemented ideas',
+	'LIST_IN_PROGRESS'		=> 'In Progress ideas',
+	'LIST_INVALID'			=> 'Invalid ideas',
 	'LIST_NEW'				=> 'New ideas',
 	'LIST_TOP'				=> 'Top ideas',
 

--- a/styles/prosilver/template/event/navbar_header_quick_links_before.html
+++ b/styles/prosilver/template/event/navbar_header_quick_links_before.html
@@ -1,0 +1,7 @@
+{% if S_REGISTERED_USER and U_SEARCH_MY_IDEAS %}
+	<li>
+		<a href="{{ U_SEARCH_MY_IDEAS }}" role="menuitem">
+			<i class="icon fa-lightbulb-o fa-fw icon-gray" aria-hidden="true"></i><span>{{ lang('LIST_EGOSEARCH') }}</span>
+		</a>
+	</li>
+{% endif %}

--- a/styles/prosilver/template/list_body.html
+++ b/styles/prosilver/template/list_body.html
@@ -2,7 +2,7 @@
 
 {% include 'overall_header.html' %}
 
-<h2>{{ lang('IDEAS_TITLE') }} :: {{ STATUS_NAME }}</h2>
+<h2>{{ lang('IDEAS_TITLE') }} <i class="icon fa-fw fa-angle-double-right"></i>{{ STATUS_NAME }}</h2>
 
 {% include 'action_bar_top.html' %}
 

--- a/tests/controller/controller_base.php
+++ b/tests/controller/controller_base.php
@@ -80,9 +80,6 @@ class controller_base extends \phpbb_test_case
 		$this->link_helper = $this->getMockBuilder('\phpbb\ideas\factory\linkhelper')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->link_helper->expects($this->atMost(3))
-			->method('get_list_link')
-			->willReturn('');
 		$this->pagination = $this->getMockBuilder('\phpbb\pagination')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/controller/list_controller_test.php
+++ b/tests/controller/list_controller_test.php
@@ -52,8 +52,8 @@ class list_controller_test extends controller_base
 				200,
 				'list_body.html',
 				array(
-					'sort' => \phpbb\ideas\factory\ideas::SORT_IMPLEMENTED,
-					'status' => 0,
+					'sort' => \phpbb\ideas\factory\ideas::SORT_DATE,
+					'status' => \phpbb\ideas\factory\ideas::$statuses['IMPLEMENTED'],
 				),
 				array(
 					'sort' => \phpbb\ideas\factory\ideas::SORT_DATE,

--- a/tests/controller/list_controller_test.php
+++ b/tests/controller/list_controller_test.php
@@ -140,6 +140,19 @@ class list_controller_test extends controller_base
 					'status' => \phpbb\ideas\factory\ideas::$statuses,
 				),
 			),
+			// My ideas list
+			array(
+				200,
+				'list_body.html',
+				array(
+					'sort' => \phpbb\ideas\factory\ideas::SORT_MYIDEAS,
+					'status' => -1,
+				),
+				array(
+					'sort' => \phpbb\ideas\factory\ideas::SORT_MYIDEAS,
+					'status' => \phpbb\ideas\factory\ideas::$statuses,
+				),
+			),
 		);
 	}
 

--- a/tests/factory/linkhelper_test.php
+++ b/tests/factory/linkhelper_test.php
@@ -85,24 +85,6 @@ class linkhelper_test extends \phpbb_database_test_case
 		$this->assertEquals($expected, $linkhelper->get_idea_link($idea_id, $mode, $hash));
 	}
 
-	public function get_list_link_test_data()
-	{
-		return array(
-			array('top', 'phpbb_ideas_list_controller#{"sort":"top"}'),
-			array('foo', 'phpbb_ideas_list_controller#{"sort":"foo"}'),
-		);
-	}
-
-	/**
-	 * @dataProvider get_list_link_test_data
-	 */
-	public function test_get_list_link($sort, $expected)
-	{
-		$linkhelper = $this->get_linkhelper();
-
-		$this->assertEquals($expected, $linkhelper->get_list_link($sort));
-	}
-
 	public function get_user_link_test_data()
 	{
 		return array(

--- a/tests/functional/ideas_test.php
+++ b/tests/functional/ideas_test.php
@@ -53,25 +53,38 @@ class ideas_test extends ideas_functional_base
 	 */
 	public function test_view_ideas_lists()
 	{
-		// Access new ideas list
+		// Test new ideas list
 		$crawler = self::request('GET', "app.php/ideas/list?sid={$this->sid}");
 		$this->assertContainsLang('OPEN_IDEAS', $crawler->filter('h2')->text());
 		$this->assertNotContainsLang('NO_IDEAS_DISPLAY', $crawler->filter('.topiclist.forums')->text());
 
-		// Access top ideas list
+		// Test top ideas list
 		$crawler = self::request('GET', "app.php/ideas/list/top?sid={$this->sid}");
-		$this->assertContainsLang('TOP_IDEAS', $crawler->filter('h2')->text());
+		$this->assertContainsLang('LIST_TOP', $crawler->filter('h2')->text());
 		$this->assertNotContainsLang('NO_IDEAS_DISPLAY', $crawler->filter('.topiclist.forums')->text());
 
-		// Access all ideas list
+		// Test all ideas list
 		$crawler = self::request('GET', "app.php/ideas/list/date?status=-1&sid={$this->sid}");
 		$this->assertContainsLang('ALL_IDEAS', $crawler->filter('h2')->text());
 		$this->assertNotContainsLang('NO_IDEAS_DISPLAY', $crawler->filter('.topiclist.forums')->text());
 
-		// Access implemented ideas list (should be empty list)
+		// Test implemented ideas list (should be empty list)
 		$crawler = self::request('GET', "app.php/ideas/list/date?status=3&sid={$this->sid}");
-		$this->assertContainsLang('IMPLEMENTED', $crawler->filter('h2')->text());
+		$this->assertContainsLang('LIST_IMPLEMENTED', $crawler->filter('h2')->text());
 		$this->assertContainsLang('NO_IDEAS_DISPLAY', $crawler->filter('.topiclist.forums')->text());
+
+		// Test my ideas list is empty when logged out
+		$crawler = self::request('GET', "app.php/ideas/list/egosearch?status=-1&sid={$this->sid}");
+		$this->assertNotContainsLang('LIST_EGOSEARCH', $crawler->filter('#quick-links')->text());
+		$this->assertContainsLang('LIST_EGOSEARCH', $crawler->filter('h2')->text());
+		$this->assertContainsLang('NO_IDEAS_DISPLAY', $crawler->filter('.topiclist.forums')->text());
+
+		// Test my ideas list works when logged in
+		$this->login();
+		$crawler = self::request('GET', "app.php/ideas/list/egosearch?status=-1&sid={$this->sid}");
+		$this->assertContainsLang('LIST_EGOSEARCH', $crawler->filter('#quick-links')->text());
+		$this->assertContainsLang('LIST_EGOSEARCH', $crawler->filter('h2')->text());
+		$this->assertNotContainsLang('NO_IDEAS_DISPLAY', $crawler->filter('.topiclist.forums')->text());
 	}
 
 	/**


### PR DESCRIPTION
This will add a "Your Ideas" quick link  when in the Ideas Centre.

![Screen Shot 2020-05-24 at 2 15 10 PM](https://user-images.githubusercontent.com/303711/82765162-213f3800-9dc9-11ea-80ec-d818d542e383.png)


Closes #123 

To make this work really required an overhaul of the old get_ideas function. This PR has broken it up into smaller chunks and also was able to eliminate the nasty switch statement nightmare that used to be there. So in addition to this new link feature, this PR has an overhaul of the whole way Ideas get sorted into various collections.