### PR TITLE
Redesign Idea Panel

### DIFF
--- a/controller/base.php
+++ b/controller/base.php
@@ -115,7 +115,7 @@ abstract class base
 		foreach ($rows as $row)
 		{
 			$this->template->assign_block_vars($block, array(
-				'ID'         => $row['idea_id'],
+				'ID'         => $row['idea_id'], // (not currently implemented)
 				'LINK'       => $this->link_helper->get_idea_link($row['idea_id']),
 				'TITLE'      => $row['idea_title'],
 				'AUTHOR'     => $this->link_helper->get_user_link($row['idea_author']),
@@ -124,7 +124,7 @@ abstract class base
 				'VOTES_UP'   => $row['idea_votes_up'],
 				'VOTES_DOWN' => $row['idea_votes_down'],
 				'USER_VOTED' => $row['u_voted'],
-				'POINTS'     => $row['idea_votes_up'] - $row['idea_votes_down'],
+				'POINTS'     => $row['idea_votes_up'] - $row['idea_votes_down'], // (not currently implemented)
 				'STATUS'     => $row['idea_status'], // for status icons (not currently implemented)
 				'LOCKED'     => $row['topic_status'] == ITEM_LOCKED,
 				'U_UNAPPROVED_IDEA'	=> (($row['topic_visibility'] == ITEM_UNAPPROVED || $row['topic_visibility'] == ITEM_REAPPROVE) && $this->auth->acl_get('m_approve', $this->config['ideas_forum_id'])) ? append_sid("{$this->root_path}mcp.{$this->php_ext}", 'i=queue&amp;mode=approve_details&amp;t=' . $row['topic_id'], true, $this->user->session_id) : '',

--- a/event/listener.php
+++ b/event/listener.php
@@ -192,8 +192,6 @@ class listener implements EventSubscriberInterface
 		$this->template->assign_vars(array(
 			'IDEA_ID'			=> $idea['idea_id'],
 			'IDEA_TITLE'		=> $idea['idea_title'],
-			'IDEA_AUTHOR'		=> $this->link_helper->get_user_link($idea['idea_author']),
-			'IDEA_DATE'			=> $this->user->format_date($idea['idea_date']),
 			'IDEA_VOTES'		=> $idea['idea_votes_up'] + $idea['idea_votes_down'],
 			'IDEA_VOTES_UP'		=> $idea['idea_votes_up'],
 			'IDEA_VOTES_DOWN'	=> $idea['idea_votes_down'],

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -69,6 +69,7 @@ $lang = array_merge($lang, array(
 	'RETURN_IDEAS'			=> '%sReturn to Ideas%s',
 	'RFC'					=> 'RFC',
 	'RFC_ERROR'				=> 'RFC must be a topic on Area51.',
+	'RFC_LINK_TEXT'			=> 'View RFC discussion on Area51',
 
 	'SEARCH_IDEAS'			=> 'Search ideas...',
 	'SCORE'                 => 'Score',

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -37,7 +37,6 @@ $lang = array_merge($lang, array(
 
 	'IDEAS'					=> 'Ideas',
 	'IDEA_DELETED'			=> 'Idea successfully deleted.',
-	'IDEA_ID'				=> 'Idea ID',
 	'IDEA_LIST'				=> 'Idea List',
 	'IDEA_NOT_FOUND'		=> 'Idea not found',
 	'IDEA_STORED_MOD'		=> 'Your idea has been submitted successfully, but it will need to be approved by a moderator before it is publicly viewable. You will be notified when your idea has been approved.<br /><br /><a href="%s">Return to Ideas</a>.',

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -65,7 +65,6 @@ $lang = array_merge($lang, array(
 	'POST_IDEA'				=> 'Post a new idea',
 	'POSTING_NEW_IDEA'		=> 'Posting a new idea',
 
-	'RATING'                => 'Rating',
 	'REMOVE_VOTE'			=> 'Remove my vote',
 	'RETURN_IDEAS'			=> '%sReturn to Ideas%s',
 	'RFC'					=> 'RFC',
@@ -103,7 +102,7 @@ $lang = array_merge($lang, array(
 	'VIEW_IDEA'				=> 'View Idea',
 	'VIEW_IMPLEMENTED'		=> 'View all implemented ideas',
 	'VIEW_LATEST'			=> 'View all open ideas',
-	'VIEW_TOP'				=> 'View all top rated ideas',
+	'VIEW_TOP'				=> 'View all top voted ideas',
 	'VIEWING_IDEAS'			=> 'Viewing Ideas',
 	'VOTE'					=> 'Vote',
 	'VOTE_DOWN'				=> 'Vote Down',

--- a/styles/prosilver/template/idea_body.html
+++ b/styles/prosilver/template/idea_body.html
@@ -8,12 +8,9 @@
 </noscript>
 <div class="panel">
 	<div class="inner">
-		<dl class="left-box details idea-panel">
-			{% if S_IS_MOD %}<dt class="idealabel">{{ lang('IDEA_ID') ~ lang('COLON') }}</dt> <dd>{{ IDEA_ID }}</dd>{% endif %}
-			<dt class="idealabel">{{ lang('AUTHOR') ~ lang('COLON') }}</dt> <dd><strong>{{ IDEA_AUTHOR }}</strong></dd>
-			<dt class="idealabel">{{ lang('POSTED') ~ lang('COLON') }}</dt> <dd>{{ IDEA_DATE }}</dd>
-			<dt class="idealabel">{{ lang('RATING') ~ lang('COLON') }}</dt>
-			<dd>
+		<div class="idea-panel">
+			<div class="idea-panel-inner">
+				<h3>{{ lang('VOTES') }}</h3>
 				<div class="rating">
 					<a {% if S_CAN_VOTE %}href="{{ U_IDEA_VOTE }}"{% endif %} class="minivote vote-up{{ not S_CAN_VOTE_UP ? ' vote-disabled' }}" title="{{ lang('VOTE_UP') }}" data-l-err="{{ lang('ERROR') }}" data-l-msg="{{ lang('VOTE_ERROR') ~ lang('COLON') }}"><i class="icon fa-check-circle user-voted{{ not S_VOTED_UP ? ' hidden' }}" aria-hidden="true"></i><i class="icon fa-thumbs-up"></i><span class="vote-count">{{ IDEA_VOTES_UP }}</span></a> &nbsp;
 					<a {% if S_CAN_VOTE %}href="{{ U_IDEA_VOTE }}"{% endif %} class="minivote vote-down{{ not S_CAN_VOTE_DOWN ? ' vote-disabled' }}" title="{{ lang('VOTE_DOWN') }}" data-l-err="{{ lang('ERROR') }}" data-l-msg="{{ lang('VOTE_ERROR') ~ lang('COLON') }}"><i class="icon fa-check-circle user-voted{{ not S_VOTED_DOWN ? ' hidden' }}" aria-hidden="true"></i><i class="icon fa-thumbs-down"></i><span class="vote-count">{{ IDEA_VOTES_DOWN }}</span></a>
@@ -45,91 +42,93 @@
 						{% endif %}
 					</ul>
 				</div>
-			</dd>
-			<dt class="idealabel">{{ lang('STATUS') ~ lang('COLON') }}</dt>
-			<dd class="status-dropdown-container dropdown-container dropdown-{S_CONTENT_FLOW_END}">
-				<span class="status-badge status-{{ IDEA_STATUS_ID }}">
-					<a href="{{ U_IDEA_STATUS_LINK }}" id="status-link"><i class="icon fa-fw {{ ideas_status_icon(IDEA_STATUS_ID) }}"></i>{{ IDEA_STATUS_NAME }}</a>
+			</div>
+			<div class="idea-panel-inner">
+				<h3>{{ lang('STATUS') }}</h3>
+				<div class="status-dropdown-container dropdown-container dropdown-{S_CONTENT_FLOW_END}">
+					<span class="status-badge status-{{ IDEA_STATUS_ID }}">
+						<a href="{{ U_IDEA_STATUS_LINK }}" id="status-link"><i class="icon fa-fw {{ ideas_status_icon(IDEA_STATUS_ID) }}"></i>{{ IDEA_STATUS_NAME }}</a>
+						{% if STATUS_ARY %}
+							<a href="#" class="dropdown-trigger"><i class="icon fa-fw fa-caret-down"></i></a>
+						{% endif %}
+					</span>
 					{% if STATUS_ARY %}
-						<a href="#" class="dropdown-trigger"><i class="icon fa-fw fa-caret-down"></i></a>
-					{% endif %}
-				</span>
-				{% if STATUS_ARY %}
-					<div class="status-dropdown dropdown">
-						<div class="pointer"><div class="pointer-inner"></div></div>
-						<ul class="dropdown-contents">
-							{% for status, id in STATUS_ARY %}
-								<li>
-									<a href="{{ U_CHANGE_STATUS }}" data-status="{{ id }}" class="change-status"><i class="icon fa-fw {{ ideas_status_icon(id) }}"></i>{{ lang(status) }}</a>
-								</li>
-							{% endfor %}
-						</ul>
-					</div>
-				{% endif %}
-			</dd>
-			{% if IDEA_RFC %}
-				<dt class="idealabel">{{ lang('RFC') ~ lang('COLON') }}</dt>
-				<dd>
-					<a id="rfclink" href="{{ IDEA_RFC }}"{% if not IDEA_RFC %} style="display:none"{% endif %}>{{ IDEA_RFC }}</a>
-					{% if S_CAN_EDIT %}
-						<a href="{{ U_EDIT_RFC }}" id="rfcedit" data-l-add="{{ lang('ADD') }}" data-l-edit="{{ lang('EDIT') }}">{% if IDEA_RFC %}<i class="icon fa-fw fa-pencil"></i>{{ lang('EDIT') }}{% else %}<i class="icon fa-fw fa-plus-circle"></i>{{ lang('ADD') }}{% endif %}</a>
-						<input type="text" id="rfceditinput" class="ideainput" value="{{ IDEA_RFC }}" data-l-err="{{ lang('ERROR') }}" data-l-msg="{{ lang('RFC_ERROR') }}" />
-					{% endif %}
-				</dd>
-			{% endif %}
-			{% if IDEA_TICKET or S_CAN_EDIT %}
-				<dt class="idealabel">{{ lang('TICKET') ~ lang('COLON') }}</dt>
-				<dd>
-					<a id="ticketlink" {% if IDEA_TICKET %}href="https://tracker.phpbb.com/browse/PHPBB3-{{ IDEA_TICKET }}">PHPBB3-{{ IDEA_TICKET }}{% else %}style="display:none">{% endif %}</a>
-					{% if S_CAN_EDIT %}
-						<a href="{{ U_EDIT_TICKET }}" id="ticketedit" data-l-add="{{ lang('ADD') }}" data-l-edit="{{ lang('EDIT') }}">{% if IDEA_TICKET %}<i class="icon fa-fw fa-pencil"></i>{{ lang('EDIT') }}{% else %}<i class="icon fa-fw fa-plus-circle"></i>{{ lang('ADD') }}{% endif %}</a>
-						<input type="text" id="ticketeditinput" class="ideainput"{% if IDEA_TICKET %} value="PHPBB3-{{ IDEA_TICKET }}"{% endif %} placeholder="PHPBB3-#####" data-l-err="{{ lang('ERROR') }}" data-l-msg="{{ lang('TICKET_ERROR') }}" />
-					{% endif %}
-				</dd>
-			{% endif %}
-			{% if IDEA_DUPLICATE or S_IS_MOD %}
-				<dt class="duplicatetoggle idealabel"{% if IDEA_STATUS_ID != STATUS_ARY.DUPLICATE %} style="display:none"{% endif %}>{{ lang('DUPLICATE') ~ lang('COLON') }}</dt>
-				<dd class="duplicatetoggle" {% if IDEA_STATUS_ID != STATUS_ARY.DUPLICATE %}style="display:none"{% endif %}>
-					<a id="duplicatelink" data-link="{{ U_IDEA_DUPLICATE }}" {% if IDEA_DUPLICATE %}href="{{ U_IDEA_DUPLICATE }}">{{ IDEA_DUPLICATE }}{% else %}style="display:none">{% endif %}</a>
-					{% if S_IS_MOD %}
-						<a href="{{ U_EDIT_DUPLICATE }}" id="duplicateedit" data-l-add="{{ lang('ADD') }}" data-l-edit="{{ lang('EDIT') }}">{% if IDEA_DUPLICATE %}<i class="icon fa-fw fa-pencil"></i>{{ lang('EDIT') }}{% else %}<i class="icon fa-fw fa-plus-circle"></i>{{ lang('ADD') }}{% endif %}</a>
-						<div class="dropdown-container dropdown-{{ S_CONTENT_FLOW_END }}">
-							<input
-								type="text"
-								name="duplicateeditinput"
-								id="duplicateeditinput"
-								value="{{ IDEA_DUPLICATE ? IDEA_DUPLICATE }}"
-								placeholder="{{ lang('DUPLICATE_PLACEHOLDER') }}"
-								class="ideainput"
-								autocomplete="off"
-								data-filter="phpbb.search.filter"
-								data-ajax="idea_search"
-								data-min-length="3"
-								data-url="{{ U_TITLE_LIVESEARCH }}"
-								data-results="#live-search"
-								data-l-err="{{ lang('ERROR') }}"
-								data-l-msg="{{ lang('TICKET_ERROR_DUP') }}"
-							/>
-							<div class="dropdown live-search hidden" id="live-search">
-								<div class="pointer"><div class="pointer-inner"></div></div>
-								<ul class="dropdown-contents search-results">
-									<li class="search-result-tpl"><span class="search-result"></span></li>
-								</ul>
-							</div>
+						<div class="status-dropdown dropdown">
+							<div class="pointer"><div class="pointer-inner"></div></div>
+							<ul class="dropdown-contents">
+								{% for status, id in STATUS_ARY %}
+									<li>
+										<a href="{{ U_CHANGE_STATUS }}" data-status="{{ id }}" class="change-status"><i class="icon fa-fw {{ ideas_status_icon(id) }}"></i>{{ lang(status) }}</a>
+									</li>
+								{% endfor %}
+							</ul>
 						</div>
 					{% endif %}
-				</dd>
-			{% endif %}
-			{% if IDEA_IMPLEMENTED or S_IS_MOD %}
-				<dt class="implementedtoggle idealabel"{% if IDEA_STATUS_ID != STATUS_ARY.IMPLEMENTED %} style="display:none"{% endif %}>{{ lang('IMPLEMENTED_VERSION') ~ lang('COLON') }}</dt>
-				<dd class="implementedtoggle" {% if IDEA_STATUS_ID != STATUS_ARY.IMPLEMENTED %}style="display:none"{% endif %}>
-					<span id="implementedversion"{% if not IDEA_IMPLEMENTED %} style="display:none;"{% endif %}>{{ IDEA_IMPLEMENTED }}</span>
-					{% if S_IS_MOD %}
-						<a href="{{ U_EDIT_IMPLEMENTED }}" id="implementededit" data-l-add="{{ lang('ADD') }}" data-l-edit="{{ lang('EDIT') }}">{% if IDEA_IMPLEMENTED %}<i class="icon fa-fw fa-pencil"></i>{{ lang('EDIT') }}{% else %}<i class="icon fa-fw fa-plus-circle"></i>{{ lang('ADD') }}{% endif %}</a>
-						<input type="text" id="implementededitinput" class="ideainput"{% if IDEA_IMPLEMENTED %} value="{{ IDEA_IMPLEMENTED }}"{% endif %} placeholder="3.x.x" data-l-err="{{ lang('ERROR') }}" data-l-msg="{{ lang('IMPLEMENTED_ERROR') }}" />
-					{% endif %}
-				</dd>
-			{% endif %}
-		</dl>
+				</div>
+				{% if IDEA_RFC %}
+					<div class="status-item">
+						{{ lang('RFC') ~ lang('COLON') }}
+						<a id="rfclink" href="{{ IDEA_RFC }}" style="{% if not IDEA_RFC %}display:none;{% endif %}overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{% if S_CAN_EDIT %}max-width:75%;{% endif %}">{{ IDEA_RFC }}</a>
+						{% if S_CAN_EDIT %}
+							<a href="{{ U_EDIT_RFC }}" id="rfcedit" data-l-add="{{ lang('ADD') }}" data-l-edit="{{ lang('EDIT') }}">{% if IDEA_RFC %}<i class="icon fa-fw fa-pencil"></i>{{ lang('EDIT') }}{% else %}<i class="icon fa-fw fa-plus-circle"></i>{{ lang('ADD') }}{% endif %}</a>
+							<input type="text" id="rfceditinput" class="ideainput" value="{{ IDEA_RFC }}" data-l-err="{{ lang('ERROR') }}" data-l-msg="{{ lang('RFC_ERROR') }}" />
+						{% endif %}
+					</div>
+				{% endif %}
+				{% if IDEA_TICKET or S_CAN_EDIT %}
+					<div class="status-item">
+						{{ lang('TICKET') ~ lang('COLON') }}
+						<a id="ticketlink" {% if IDEA_TICKET %}href="https://tracker.phpbb.com/browse/PHPBB3-{{ IDEA_TICKET }}">PHPBB3-{{ IDEA_TICKET }}{% else %}style="display:none">{% endif %}</a>
+						{% if S_CAN_EDIT %}
+							<a href="{{ U_EDIT_TICKET }}" id="ticketedit" data-l-add="{{ lang('ADD') }}" data-l-edit="{{ lang('EDIT') }}">{% if IDEA_TICKET %}<i class="icon fa-fw fa-pencil"></i>{{ lang('EDIT') }}{% else %}<i class="icon fa-fw fa-plus-circle"></i>{{ lang('ADD') }}{% endif %}</a>
+							<input type="text" id="ticketeditinput" class="ideainput"{% if IDEA_TICKET %} value="PHPBB3-{{ IDEA_TICKET }}"{% endif %} placeholder="PHPBB3-#####" data-l-err="{{ lang('ERROR') }}" data-l-msg="{{ lang('TICKET_ERROR') }}" />
+						{% endif %}
+					</div>
+				{% endif %}
+				{% if IDEA_DUPLICATE or S_IS_MOD %}
+					<div class="status-item duplicatetoggle" {% if IDEA_STATUS_ID != STATUS_ARY.DUPLICATE %}style="display:none"{% endif %}>
+						{{ lang('DUPLICATE') ~ lang('COLON') }}
+						<a id="duplicatelink" data-link="{{ U_IDEA_DUPLICATE }}" {% if IDEA_DUPLICATE %}href="{{ U_IDEA_DUPLICATE }}">{{ IDEA_DUPLICATE }}{% else %}style="display:none">{% endif %}</a>
+						{% if S_IS_MOD %}
+							<a href="{{ U_EDIT_DUPLICATE }}" id="duplicateedit" data-l-add="{{ lang('ADD') }}" data-l-edit="{{ lang('EDIT') }}">{% if IDEA_DUPLICATE %}<i class="icon fa-fw fa-pencil"></i>{{ lang('EDIT') }}{% else %}<i class="icon fa-fw fa-plus-circle"></i>{{ lang('ADD') }}{% endif %}</a>
+							<div class="dropdown-container dropdown-{{ S_CONTENT_FLOW_END }}">
+								<input
+									type="text"
+									name="duplicateeditinput"
+									id="duplicateeditinput"
+									value="{{ IDEA_DUPLICATE ? IDEA_DUPLICATE }}"
+									placeholder="{{ lang('DUPLICATE_PLACEHOLDER') }}"
+									class="ideainput"
+									autocomplete="off"
+									data-filter="phpbb.search.filter"
+									data-ajax="idea_search"
+									data-min-length="3"
+									data-url="{{ U_TITLE_LIVESEARCH }}"
+									data-results="#live-search"
+									data-l-err="{{ lang('ERROR') }}"
+									data-l-msg="{{ lang('TICKET_ERROR_DUP') }}"
+								/>
+								<div class="dropdown live-search hidden" id="live-search">
+									<div class="pointer"><div class="pointer-inner"></div></div>
+									<ul class="dropdown-contents search-results">
+										<li class="search-result-tpl"><span class="search-result"></span></li>
+									</ul>
+								</div>
+							</div>
+						{% endif %}
+					</div>
+				{% endif %}
+				{% if IDEA_IMPLEMENTED or S_IS_MOD %}
+					<div class="status-item implementedtoggle" {% if IDEA_STATUS_ID != STATUS_ARY.IMPLEMENTED %}style="display:none"{% endif %}>
+						{{ lang('IMPLEMENTED_VERSION') ~ lang('COLON') }}
+						<span id="implementedversion"{% if not IDEA_IMPLEMENTED %} style="display:none;"{% endif %}>{{ IDEA_IMPLEMENTED }}</span>
+						{% if S_IS_MOD %}
+							<a href="{{ U_EDIT_IMPLEMENTED }}" id="implementededit" data-l-add="{{ lang('ADD') }}" data-l-edit="{{ lang('EDIT') }}">{% if IDEA_IMPLEMENTED %}<i class="icon fa-fw fa-pencil"></i>{{ lang('EDIT') }}{% else %}<i class="icon fa-fw fa-plus-circle"></i>{{ lang('ADD') }}{% endif %}</a>
+							<input type="text" id="implementededitinput" class="ideainput"{% if IDEA_IMPLEMENTED %} value="{{ IDEA_IMPLEMENTED }}"{% endif %} placeholder="3.x.x" data-l-err="{{ lang('ERROR') }}" data-l-msg="{{ lang('IMPLEMENTED_ERROR') }}" />
+						{% endif %}
+					</div>
+				{% endif %}
+			</div>
+		</div>
 	</div>
 </div>

--- a/styles/prosilver/template/idea_body.html
+++ b/styles/prosilver/template/idea_body.html
@@ -8,8 +8,8 @@
 </noscript>
 <div class="panel">
 	<div class="inner">
-		<div class="idea-panel">
-			<div class="idea-panel-inner">
+		<div class="idea-panel flex-box flex-wrap">
+			<div class="idea-panel-inner flex-grow">
 				<h3>{{ lang('VOTES') }}</h3>
 				<div class="rating">
 					<a {% if S_CAN_VOTE %}href="{{ U_IDEA_VOTE }}"{% endif %} class="minivote vote-up{{ not S_CAN_VOTE_UP ? ' vote-disabled' }}" title="{{ lang('VOTE_UP') }}" data-l-err="{{ lang('ERROR') }}" data-l-msg="{{ lang('VOTE_ERROR') ~ lang('COLON') }}"><i class="icon fa-check-circle user-voted{{ not S_VOTED_UP ? ' hidden' }}" aria-hidden="true"></i><i class="icon fa-thumbs-up"></i><span class="vote-count">{{ IDEA_VOTES_UP }}</span></a> &nbsp;
@@ -43,7 +43,7 @@
 					</ul>
 				</div>
 			</div>
-			<div class="idea-panel-inner">
+			<div class="idea-panel-inner flex-grow">
 				<h3>{{ lang('STATUS') }}</h3>
 				<div class="status-dropdown-container dropdown-container dropdown-{S_CONTENT_FLOW_END}">
 					<span class="status-badge status-{{ IDEA_STATUS_ID }}">
@@ -66,7 +66,7 @@
 					{% endif %}
 				</div>
 				{% if IDEA_RFC %}
-					<div class="status-item">
+					<div class="status-item flex-box flex-align-end">
 						{{ lang('RFC') ~ lang('COLON') }}
 						<a id="rfclink" href="{{ IDEA_RFC }}" style="{% if not IDEA_RFC %}display:none;{% endif %}overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{% if S_CAN_EDIT %}max-width:75%;{% endif %}">{{ lang('RFC_LINK_TEXT') }}</a>
 						{% if S_CAN_EDIT %}
@@ -76,7 +76,7 @@
 					</div>
 				{% endif %}
 				{% if IDEA_TICKET or S_CAN_EDIT %}
-					<div class="status-item">
+					<div class="status-item flex-box flex-align-end">
 						{{ lang('TICKET') ~ lang('COLON') }}
 						<a id="ticketlink" {% if IDEA_TICKET %}href="https://tracker.phpbb.com/browse/PHPBB3-{{ IDEA_TICKET }}">PHPBB3-{{ IDEA_TICKET }}{% else %}style="display:none">{% endif %}</a>
 						{% if S_CAN_EDIT %}
@@ -86,7 +86,7 @@
 					</div>
 				{% endif %}
 				{% if IDEA_DUPLICATE or S_IS_MOD %}
-					<div class="status-item duplicatetoggle" {% if IDEA_STATUS_ID != STATUS_ARY.DUPLICATE %}style="display:none"{% endif %}>
+					<div class="status-item flex-box flex-align-end duplicatetoggle" {% if IDEA_STATUS_ID != STATUS_ARY.DUPLICATE %}style="display:none"{% endif %}>
 						{{ lang('DUPLICATE') ~ lang('COLON') }}
 						<a id="duplicatelink" data-link="{{ U_IDEA_DUPLICATE }}" {% if IDEA_DUPLICATE %}href="{{ U_IDEA_DUPLICATE }}">{{ IDEA_DUPLICATE }}{% else %}style="display:none">{% endif %}</a>
 						{% if S_IS_MOD %}
@@ -119,7 +119,7 @@
 					</div>
 				{% endif %}
 				{% if IDEA_IMPLEMENTED or S_IS_MOD %}
-					<div class="status-item implementedtoggle" {% if IDEA_STATUS_ID != STATUS_ARY.IMPLEMENTED %}style="display:none"{% endif %}>
+					<div class="status-item flex-box flex-align-end implementedtoggle" {% if IDEA_STATUS_ID != STATUS_ARY.IMPLEMENTED %}style="display:none"{% endif %}>
 						{{ lang('IMPLEMENTED_VERSION') ~ lang('COLON') }}
 						<span id="implementedversion"{% if not IDEA_IMPLEMENTED %} style="display:none;"{% endif %}>{{ IDEA_IMPLEMENTED }}</span>
 						{% if S_IS_MOD %}

--- a/styles/prosilver/template/idea_body.html
+++ b/styles/prosilver/template/idea_body.html
@@ -68,7 +68,7 @@
 				{% if IDEA_RFC %}
 					<div class="status-item">
 						{{ lang('RFC') ~ lang('COLON') }}
-						<a id="rfclink" href="{{ IDEA_RFC }}" style="{% if not IDEA_RFC %}display:none;{% endif %}overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{% if S_CAN_EDIT %}max-width:75%;{% endif %}">{{ IDEA_RFC }}</a>
+						<a id="rfclink" href="{{ IDEA_RFC }}" style="{% if not IDEA_RFC %}display:none;{% endif %}overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{% if S_CAN_EDIT %}max-width:75%;{% endif %}">{{ lang('RFC_LINK_TEXT') }}</a>
 						{% if S_CAN_EDIT %}
 							<a href="{{ U_EDIT_RFC }}" id="rfcedit" data-l-add="{{ lang('ADD') }}" data-l-edit="{{ lang('EDIT') }}">{% if IDEA_RFC %}<i class="icon fa-fw fa-pencil"></i>{{ lang('EDIT') }}{% else %}<i class="icon fa-fw fa-plus-circle"></i>{{ lang('ADD') }}{% endif %}</a>
 							<input type="text" id="rfceditinput" class="ideainput" value="{{ IDEA_RFC }}" data-l-err="{{ lang('ERROR') }}" data-l-msg="{{ lang('RFC_ERROR') }}" />

--- a/styles/prosilver/template/index_body.html
+++ b/styles/prosilver/template/index_body.html
@@ -17,7 +17,7 @@
 			<li class="header">
 				<dl class="row-item">
 					<dt><div class="list-inner">{{ lang('IDEAS') }}</div></dt>
-					<dd class="posts">{{ lang('RATING') }}</dd>
+					<dd class="posts">{{ lang('VOTES') }}</dd>
 				</dl>
 			</li>
 		</ul>
@@ -37,7 +37,7 @@
 			<li class="header">
 				<dl class="row-item">
 					<dt><div class="list-inner">{{ lang('IDEAS') }}</div></dt>
-					<dd class="posts">{{ lang('RATING') }}</dd>
+					<dd class="posts">{{ lang('VOTES') }}</dd>
 				</dl>
 			</li>
 		</ul>
@@ -57,7 +57,7 @@
 			<li class="header">
 				<dl class="row-item">
 					<dt><div class="list-inner">{{ lang('IDEAS') }}</div></dt>
-					<dd class="posts">{{ lang('RATING') }}</dd>
+					<dd class="posts">{{ lang('VOTES') }}</dd>
 				</dl>
 			</li>
 		</ul>

--- a/styles/prosilver/template/index_body.html
+++ b/styles/prosilver/template/index_body.html
@@ -7,10 +7,12 @@
 {% include 'action_bar_top.html' %}
 
 {# TOP IDEAS #}
-<h2 class="push-left">{{ lang('TOP_IDEAS') }}</h2>
-{% if top_ideas %}
-	<a class="button view-all" href="{{ U_VIEW_TOP }}"><i class="icon fa-fw fa-line-chart"></i> <span>{{ lang('VIEW_TOP') }}</span></a>
-{% endif %}
+<div class="flex-box flex-align-end flex-justify">
+	<h2>{{ lang('TOP_IDEAS') }}</h2>
+	{% if top_ideas %}
+		<a class="button view-all" href="{{ U_VIEW_TOP }}"><i class="icon fa-fw fa-line-chart"></i> <span>{{ lang('VIEW_TOP') }}</span></a>
+	{% endif %}
+</div>
 <div class="forumbg">
 	<div class="inner">
 		<ul class="topiclist">
@@ -27,11 +29,13 @@
 </div>
 
 {# LATEST IDEAS #}
-<h2 class="push-left">{{ lang('LATEST_IDEAS') }}</h2>
-{% if latest_ideas %}
-	<a class="button view-all" href="{{ U_VIEW_LATEST }}"><i class="icon fa-fw fa-lightbulb-o"></i> <span>{{ lang('VIEW_LATEST') }}</span></a>
-{% endif %}
-<div class="forumbg" style="margin-top: 10px">
+<div class="flex-box flex-align-end flex-justify">
+	<h2>{{ lang('LATEST_IDEAS') }}</h2>
+	{% if latest_ideas %}
+		<a class="button view-all" href="{{ U_VIEW_LATEST }}"><i class="icon fa-fw fa-lightbulb-o"></i> <span>{{ lang('VIEW_LATEST') }}</span></a>
+	{% endif %}
+</div>
+<div class="forumbg">
 	<div class="inner">
 		<ul class="topiclist">
 			<li class="header">
@@ -47,11 +51,13 @@
 </div>
 
 {# IMPLEMENTED IDEAS #}
-<h2 class="push-left">{{ lang('IMPLEMENTED_IDEAS') }}</h2>
-{% if implemented_ideas %}
-	<a class="button view-all" href="{{ U_VIEW_IMPLEMENTED }}"><i class="icon fa-fw fa-code-fork fa-flip-vertical"></i> <span>{{ lang('VIEW_IMPLEMENTED') }}</span></a>
-{% endif %}
-<div class="forumbg" style="margin-top: 10px">
+<div class="flex-box flex-align-end flex-justify">
+	<h2>{{ lang('IMPLEMENTED_IDEAS') }}</h2>
+	{% if implemented_ideas %}
+		<a class="button view-all" href="{{ U_VIEW_IMPLEMENTED }}"><i class="icon fa-fw fa-code-fork fa-flip-vertical"></i> <span>{{ lang('VIEW_IMPLEMENTED') }}</span></a>
+	{% endif %}
+</div>
+<div class="forumbg">
 	<div class="inner">
 		<ul class="topiclist">
 			<li class="header">

--- a/styles/prosilver/template/list_body.html
+++ b/styles/prosilver/template/list_body.html
@@ -12,7 +12,7 @@
 			<li class="header">
 				<dl class="row-item">
 					<dt><div class="list-inner">{{ lang('IDEAS') }}</div></dt>
-					<dd class="posts">{{ lang('RATING') }}</dd>
+					<dd class="posts">{{ lang('VOTES') }}</dd>
 				</dl>
 			</li>
 		</ul>

--- a/styles/prosilver/theme/ideas.css
+++ b/styles/prosilver/theme/ideas.css
@@ -5,6 +5,11 @@ dd.topics {
 	padding-left: 10px !important;
 }
 
+.rtl dd.topics {
+	text-align: right;
+	padding-right: 10px !important;
+}
+
 .fa-lightbulb-o {
 	font-weight: 400 !important;
 }

--- a/styles/prosilver/theme/ideas.css
+++ b/styles/prosilver/theme/ideas.css
@@ -1,6 +1,6 @@
 /* flex box classes */
 .flex-box {
-	display: flex !important;
+	display: flex;
 }
 
 .flex-wrap {
@@ -248,8 +248,4 @@ dd.topics {
 
 .status-5 {
 	background-color: #b22222;
-}
-
-.rating {
-	margin-top: 4px;
 }

--- a/styles/prosilver/theme/ideas.css
+++ b/styles/prosilver/theme/ideas.css
@@ -118,13 +118,15 @@ dd.topics {
 /* Idea Body Styles */
 .idea-panel {
 	font-size: 11px;
+	display: flex;
+	flex-wrap: wrap;
 	width: 100%;
 }
 
 .idea-panel-inner {
-	float: left;
+	flex-grow: 1;
 	box-sizing: border-box;
-	width: 50%;
+	width: 400px;
 	padding: 0 3px;
 }
 
@@ -235,15 +237,4 @@ dd.topics {
 
 .rating {
 	margin-top: 4px;
-}
-
-@media (max-width: 900px) {
-	.idea-panel-inner {
-		float: none;
-		width: 100%;
-	}
-
-	.status-item {
-		align-items: flex-start;
-	}
 }

--- a/styles/prosilver/theme/ideas.css
+++ b/styles/prosilver/theme/ideas.css
@@ -1,3 +1,28 @@
+/* flex box classes */
+.flex-box {
+	display: flex !important;
+}
+
+.flex-wrap {
+	flex-wrap: wrap;
+}
+
+.flex-grow {
+	flex-grow: 1;
+}
+
+.flex-justify {
+	justify-content: space-between;
+}
+
+.flex-align-end {
+	align-items: flex-end;
+}
+
+.flex-align-center {
+	align-items: center;
+}
+
 /* Common Styles */
 dd.topics {
 	text-align: left;
@@ -93,16 +118,11 @@ dd.topics {
 /* Ideas Lists Styles */
 .view-all {
 	color: #536482;
-	float: right;
 	margin: 0.8em 0 0.2em;
 }
 
 .view-all:hover {
 	color: #536482;
-}
-
-.push-left {
-	float: left;
 }
 
 @media (min-width: 701px) and (max-width: 950px) {
@@ -118,13 +138,10 @@ dd.topics {
 /* Idea Body Styles */
 .idea-panel {
 	font-size: 11px;
-	display: flex;
-	flex-wrap: wrap;
 	width: 100%;
 }
 
 .idea-panel-inner {
-	flex-grow: 1;
 	box-sizing: border-box;
 	width: 400px;
 	padding: 0 3px;
@@ -185,8 +202,6 @@ dd.topics {
 }
 
 .status-item {
-	display: flex;
-	align-items: flex-end;
 	min-height: 18px;
 	margin: 4px 0;
 }

--- a/styles/prosilver/theme/ideas.css
+++ b/styles/prosilver/theme/ideas.css
@@ -9,10 +9,6 @@ dd.topics {
 	font-weight: 400 !important;
 }
 
-.idea-panel dd {
-	overflow: visible !important;
-}
-
 /* Vote buttons */
 .minivote {
 	line-height: normal;
@@ -115,6 +111,18 @@ dd.topics {
 }
 
 /* Idea Body Styles */
+.idea-panel {
+	font-size: 11px;
+	width: 100%;
+}
+
+.idea-panel-inner {
+	float: left;
+	box-sizing: border-box;
+	width: 50%;
+	padding: 0 3px;
+}
+
 .votes,
 .successvoted {
 	font-weight: bold;
@@ -164,13 +172,21 @@ dd.topics {
 	display: none;
 }
 
-.idealabel {
-	width: 120px !important;
-}
-
 .ideainput {
 	display: none;
-	width: 300px;
+	width: 200px;
+}
+
+.status-item {
+	display: flex;
+	align-items: flex-end;
+	min-height: 18px;
+	margin: 4px 0;
+}
+
+.status-item a,
+.status-item input {
+	margin-left: 4px;
 }
 
 .status-badge {
@@ -212,11 +228,17 @@ dd.topics {
 	background-color: #b22222;
 }
 
-.idea-panel {
-	line-height: 16px;
-	width: 100%;
-}
-
 .rating {
 	margin-top: 4px;
+}
+
+@media (max-width: 900px) {
+	.idea-panel-inner {
+		float: none;
+		width: 100%;
+	}
+
+	.status-item {
+		align-items: flex-start;
+	}
 }


### PR DESCRIPTION
Remove the redundant infomation, and make better use of the space available for the ideas panel.

A typical standard view:
![Screen Shot 2020-05-26 at 1 00 30 PM](https://user-images.githubusercontent.com/303711/82945510-ec122180-9f51-11ea-988e-9fdf5ff5a4c6.png)

A view a moderator might see:
![Screen Shot 2020-05-26 at 1 10 15 PM](https://user-images.githubusercontent.com/303711/82945882-51661280-9f52-11ea-8d82-e73e48795c84.png)

And in responsive/mobile view:
![Screen Shot 2020-05-26 at 1 09 22 PM](https://user-images.githubusercontent.com/303711/82945765-28458200-9f52-11ea-88e7-3fdceaf4ee73.png)

